### PR TITLE
[chore] gradle.yml CI/CD 트리거 브랜치를 dev로 변경

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@ name: Savit Server CI/CD with Docker
 
 on:
   push:
-    branches: ['feature/cicd'] # main 브랜치에 push할 때 실행
+    branches: ['dev'] # main 브랜치에 push할 때 실행 (현재 팀 레포상 dev 브랜치에서 트리거 되게끔)
 
 jobs:
   deploy:


### PR DESCRIPTION
## ✅ 작업 내용
- 브랜치명 변경

## 🔧 주요 변경 사항
- gradle.yml 에서 현재 팀 레포상 dev 브랜치에서 트리거 되게끔 브랜치명 변경 (feature/cicd -> dev)
(기존에 feature/cicd 브랜치에서만 작동하던 GitHub Actions 워크플로우를 실제 메인 브랜치인 dev에서 작동하도록 수정)

## 📌 관련 이슈


## 🚨 체크리스트
- [ ] 빌드 오류 없음
- [ ] 테스트 코드 작성 또는 실행 확인
- [ ] 커밋 메시지 컨벤션을 지킴
- [ ] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함