### PR TITLE
[fix/chore] CODEF 카드 응답 처리 및 임시 암호화 적용 (#35, #39)

### DIFF
--- a/src/main/java/com/savit/card/service/CardService.java
+++ b/src/main/java/com/savit/card/service/CardService.java
@@ -42,7 +42,7 @@ public class CardService {
         account.put("loginType", "1");
         account.put("loginTypeLevel", "2");
         account.put("id", req.getLoginId());
-        account.put("password", codefUtil.encryptRSA(req.getLoginPw()));
+        account.put("password", req.getLoginPw());
         account.put("birthDate", req.getBirthDate());
 
         List<HashMap<String, Object>> list = List.of(account);
@@ -84,8 +84,21 @@ public class CardService {
         );
         log.info("[CODEF] createAccount 응답 = {}", resp);
 
-        Map<?, ?> map = new ObjectMapper().readValue(resp, Map.class);
-        return (List<Map<String, Object>>) map.get("data");
+
+        Map<String, Object> map = new ObjectMapper().readValue(resp, Map.class);
+        Object dataObj = map.get("data");
+
+        List<Map<String, Object>> cardList;
+
+        if (dataObj instanceof List) {
+            cardList = (List<Map<String, Object>>) dataObj;
+        } else if (dataObj instanceof Map) {
+            cardList = List.of((Map<String, Object>) dataObj);
+        } else {
+            throw new IllegalStateException("예상치 못한 카드 응답 형식: " + dataObj);
+        }
+
+        return cardList;
     }
 
     public void saveCards(List<Map<String, Object>> cardDataList,
@@ -98,7 +111,7 @@ public class CardService {
         List<Card> cards = cardDataList.stream().map(data -> Card.builder()
                         .connectedId(connectedId)
                         .organization(organization)
-                        .cardName((String) data.get("cardName"))
+                        .cardName((String) data.get("resCardName"))
                         .issuer((String) data.get("issuer"))
                         .encryptedCardNo(encryptedCardNo)
                         .resCardNo((String) data.get("resCardNo"))

--- a/src/main/java/com/savit/card/service/CardService.java
+++ b/src/main/java/com/savit/card/service/CardService.java
@@ -42,7 +42,9 @@ public class CardService {
         account.put("loginType", "1");
         account.put("loginTypeLevel", "2");
         account.put("id", req.getLoginId());
-        account.put("password", req.getLoginPw());
+        // 카드사 비밀번호 테스트용으로 여기서 암호화 진행
+        // 추후 req.fetLoginPw() 만 사용
+        account.put("password", codefUtil.encryptRSA(req.getLoginPw()));
         account.put("birthDate", req.getBirthDate());
 
         List<HashMap<String, Object>> list = List.of(account);
@@ -113,11 +115,15 @@ public class CardService {
                         .organization(organization)
                         .cardName((String) data.get("resCardName"))
                         .issuer((String) data.get("issuer"))
-                        .encryptedCardNo(encryptedCardNo)
+                        // 사용자입력부 평문 입력 -> 프론트에서 encryptRSA 한 값 받아옴
+                        // 테스트 위해 임시로 codefUtil.encryptRSA(encryptedCardNo) 사용
+                        // 추후 .encryptedCardNo(encryptedCardNo) 로 변경해야 함
+                        .encryptedCardNo(codefUtil.encryptRSA(encryptedCardNo))
                         .resCardNo((String) data.get("resCardNo"))
                         .resCardType((String) data.get("resCardType"))
                         .resSleepYn((String) data.get("resSleepYn"))
-                        .cardPassword(cardPassword)
+                        // 비번도 마찬가지로 추후 변경
+                        .cardPassword(codefUtil.encryptRSA(cardPassword))
                         .registeredAt(LocalDateTime.now())
                         .userId(userId)
                         .build())


### PR DESCRIPTION
## ✅ 작업 내용
- CODEF 카드 응답 형식 중 `data`가 List 또는 단일 Map 형태로 유동적으로 내려오는 경우 처리
- 카드명 응답 필드 변경 (`cardName` → `resCardName`) 대응
- 프론트에서 암호화된 카드 비밀번호를 백엔드에서 재암호화하지 않고 그대로 전달하도록 수정
- 프론트 연동 전 테스트를 위해 카드번호, 카드 비밀번호를 백엔드에서 임시 RSA 암호화

## 🔧 주요 변경 사항
- `CardService.java`
  - `fetchCardList()` 응답 타입 유동성 대응
  - 카드명 파싱 키 변경: `resCardName`
  - 카드 비밀번호 재암호화 제거
  - 프론트 암호화 적용 전 임시 RSA 암호화 처리 (주석 명시)

## 📌 관련 이슈
- closes #35
- closes #39

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 실행 또는 수동 테스트 완료
- [x] 커밋 메시지 및 PR 제목 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명 작성