### PR TITLE
[test] CardService, CodefTokenService 단위 테스트 추가 (#44)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ dependencies {
     testImplementation "org.springframework:spring-test:${springVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+    // Mokito
+    testImplementation 'org.mockito:mockito-core:5.12.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
 }
 
 test {

--- a/src/test/java/com/savit/card/CardServiceTest.java
+++ b/src/test/java/com/savit/card/CardServiceTest.java
@@ -1,0 +1,110 @@
+package com.savit.card;
+
+import com.savit.card.dto.CardRegisterRequest;
+import com.savit.card.mapper.CardMapper;
+import com.savit.card.service.CardService;
+import com.savit.card.service.CodefTokenService;
+import com.savit.card.util.CodefUtil;
+import io.codef.api.EasyCodef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CardServiceTest {
+
+    @Mock private CodefTokenService codefTokenService;
+    @Mock private CodefUtil codefUtil;
+    @Mock private CardMapper cardMapper;
+    @Mock private EasyCodef codefClient;
+
+    @InjectMocks
+    private CardService cardService;
+
+    @Test
+    void registerAccount_정상응답_connectedId_반환() throws Exception {
+        CardRegisterRequest req = new CardRegisterRequest();
+        req.setLoginId("testId");
+        req.setLoginPw("testPw");
+        req.setBirthDate("19900101");
+        req.setOrganization("0306");
+
+        String connectedId = "mock-connected-id";
+        String mockResp = "{\"data\":{\"connectedId\":\"" + connectedId + "\"}}";
+
+        when(codefTokenService.getAccessToken()).thenReturn("token");
+        when(codefUtil.getClientId()).thenReturn("client-id");
+        when(codefUtil.encryptRSA(any())).thenReturn("encryptedPw");
+        when(codefUtil.newClient()).thenReturn(codefClient);
+        when(codefClient.createAccount(any(), any())).thenReturn(mockResp);
+
+        String result = cardService.registerAccount(req);
+
+        assertEquals(connectedId, result);
+    }
+
+    @Test
+    void registerAccount_connectedId없을경우_예외발생() throws Exception {
+        CardRegisterRequest req = new CardRegisterRequest();
+        req.setLoginId("id");
+        req.setLoginPw("pw");
+        req.setBirthDate("19900101");
+        req.setOrganization("0306");
+
+        String mockResp = "{\"data\":{}}";
+
+        when(codefTokenService.getAccessToken()).thenReturn("token");
+        when(codefUtil.getClientId()).thenReturn("client-id");
+        when(codefUtil.encryptRSA(any())).thenReturn("enc");
+        when(codefUtil.newClient()).thenReturn(codefClient);
+        when(codefClient.createAccount(any(), any())).thenReturn(mockResp);
+
+        assertThrows(IllegalStateException.class, () -> cardService.registerAccount(req));
+    }
+
+    @Test
+    void fetchCardList_정상응답() throws Exception {
+        String connectedId = "cid";
+        String organization = "0306";
+        String birthDate = "19900101";
+
+        String mockResp = "{\"data\":[{\"cardName\":\"신한카드\",\"resCardNo\":\"1234\"}]}";
+
+        when(codefTokenService.getAccessToken()).thenReturn("token");
+        when(codefUtil.getClientId()).thenReturn("client-id");
+        when(codefUtil.newClient()).thenReturn(codefClient);
+        when(codefClient.requestProduct(any(), any(), any())).thenReturn(mockResp);
+
+        List<Map<String, Object>> result = cardService.fetchCardList(connectedId, organization, birthDate);
+
+        assertFalse(result.isEmpty());
+        assertEquals("신한카드", result.get(0).get("cardName"));
+    }
+
+    @Test
+    void saveCards_cardMapper_호출확인() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("cardName", "카드");
+        data.put("issuer", "신한");
+        data.put("resCardNo", "1234");
+        data.put("resCardType", "체크");
+        data.put("resSleepYn", "N");
+
+        List<Map<String, Object>> list = List.of(data);
+
+        cardService.saveCards(list, "cid", "org", 1L, "encNo", "00");
+
+        verify(cardMapper).insertCards(anyList());
+    }
+}

--- a/src/test/java/com/savit/card/CodefTokenServiceTest.java
+++ b/src/test/java/com/savit/card/CodefTokenServiceTest.java
@@ -1,0 +1,71 @@
+package com.savit.card;
+
+import com.savit.card.domain.CodefToken;
+import com.savit.card.repository.CodefTokenRepository;
+import com.savit.card.service.CodefTokenService;
+import com.savit.card.util.CodefUtil;
+import io.codef.api.EasyCodef;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CodefTokenServiceTest {
+
+    @Mock private CodefTokenRepository tokenRepository;
+    @Mock private CodefUtil codefUtil;
+    @Mock private EasyCodef codefClient;
+
+    @InjectMocks
+    private CodefTokenService tokenService;
+
+    @Test
+    void getAccessToken_유효토큰존재시_재사용() {
+        CodefToken token = CodefToken.builder()
+                .accessToken("valid-token")
+                .expiresAt(LocalDateTime.now().plusDays(3))
+                .build();
+
+        when(tokenRepository.findValidToken()).thenReturn(Optional.of(token));
+
+        String result = tokenService.getAccessToken();
+
+        assertEquals("valid-token", result);
+    }
+
+    @Test
+    void getAccessToken_유효토큰없을때_신규발급후저장() throws Exception {
+        when(tokenRepository.findValidToken()).thenReturn(Optional.empty());
+        when(codefUtil.newClient()).thenReturn(codefClient);
+        when(codefClient.requestToken(any())).thenReturn("new-token");
+
+        String result = tokenService.getAccessToken();
+
+        assertEquals("new-token", result);
+        verify(tokenRepository).save(any(CodefToken.class));
+    }
+
+    @Test
+    void issueAndSaveToken_빈토큰반환시_예외발생() throws Exception {
+        when(tokenRepository.findValidToken()).thenReturn(Optional.empty());
+        when(codefUtil.newClient()).thenReturn(codefClient);
+        when(codefClient.requestToken(any())).thenReturn("");
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> {
+            tokenService.getAccessToken();
+        });
+
+        assertTrue(e.getMessage().contains("CODEF 토큰 발급 실패"));
+        assertInstanceOf(IllegalStateException.class, e.getCause());
+        assertEquals("CODEF 토큰 발급 실패 (빈 토큰)", e.getCause().getMessage());
+    }
+
+}


### PR DESCRIPTION
## ✅ 작업 내용
- `CardService`, `CodefTokenService`에 대한 단위 테스트 작성
- 정상 흐름 및 예외 상황 테스트 포함
- 내부 예외 (`cause`)까지 검증하여 로직 신뢰성 확보

## 🔧 주요 변경 사항
- `CardServiceTest.java`, `CodefTokenServiceTest.java` 생성
- Mockito 기반 JUnit 5 테스트 구조 적용
- 빈 토큰 → IllegalStateException → RuntimeException wrapping 및 내부 cause 검증 포함

## 🔍 테스트 상세
- `registerAccount` → connectedId 응답 확인 + 미존재 시 예외 검증
- `fetchCardList` → 카드 목록 정상 파싱 확인
- `saveCards` → DB 저장 로직 호출 여부 확인
- `getAccessToken` → 유효 토큰 재사용 및 신규 발급 시 저장 여부 확인
- 빈 토큰 → `IllegalStateException` → `RuntimeException` wrapping 검증

## 📌 관련 이슈
- closes #44

## 🔎 확인 사항
- [x] `./gradlew test`로 전체 테스트 성공
- [x] 불필요한 외부 API 호출 없음 (모두 mock 처리)
- [x] 예외 메시지, 내부 cause 검증 포함