### PR TITLE
[chore] 신규 EC2 인스턴스 배포 테스트를 위한 CI/CD 트리거(test/cicd 브랜치)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@ name: Savit Server CI/CD with Docker
 
 on:
   push:
-    branches: ['dev'] # main 브랜치에 push할 때 실행 (현재 팀 레포상 dev 브랜치에서 트리거 되게끔)
+    branches: ['test/cicd'] # main 브랜치에 push할 때 실행 (현재 팀 레포상 dev 브랜치에서 트리거 되게끔)
 
 jobs:
   deploy:


### PR DESCRIPTION
## ✅ 작업 내용
- 신규 EC2 인스턴스를 세팅한 후, CI/CD가 정상 작동하는지 확인하기 위한 테스트 PR입니다.

## 🔧 주요 변경 사항
- GitHub Actions 워크플로우(`gradle.yml`)의 트리거 브랜치를 임시로 `test/cicd`로 변경
- 도커 로그인 및 배포 스크립트 정상 작동 여부 확인 목적

## 📌 관련 이슈
- X

## 🚨 참고사항
- 이 PR은 테스트용 브랜치에서만 사용되며, 기능 개발과는 무관