### PR TITLE
[feat] 이번 주 참여가능 챌린지 조회 기능 구현 (#51)

### DIFF
--- a/src/main/java/com/savit/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/savit/challenge/controller/ChallengeController.java
@@ -1,0 +1,27 @@
+package com.savit.challenge.controller;
+
+import com.savit.challenge.dto.ChallengeListDTO;
+import com.savit.challenge.service.ChallengeService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/challenge")
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeController {
+
+    private  final ChallengeService challengeService;
+    @GetMapping
+    public ResponseEntity<List<ChallengeListDTO>> getChallengeList () {
+        List<ChallengeListDTO> result = challengeService.getChallengeList();
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/savit/challenge/dto/ChallengeListDTO.java
+++ b/src/main/java/com/savit/challenge/dto/ChallengeListDTO.java
@@ -1,0 +1,17 @@
+package com.savit.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChallengeListDTO {
+    private String title;
+    private String startDate;
+    private String endDate;
+    private String categoryName;
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
@@ -1,0 +1,11 @@
+package com.savit.challenge.mapper;
+
+import com.savit.challenge.dto.ChallengeListDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ChallengeMapper {
+    List<ChallengeListDTO> getChallengeList();
+}

--- a/src/main/java/com/savit/challenge/service/ChallengeService.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeService.java
@@ -1,0 +1,9 @@
+package com.savit.challenge.service;
+
+import com.savit.challenge.dto.ChallengeListDTO;
+
+import java.util.List;
+
+public interface ChallengeService {
+    List<ChallengeListDTO> getChallengeList();
+}

--- a/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
@@ -1,0 +1,24 @@
+package com.savit.challenge.service;
+
+import com.savit.challenge.dto.ChallengeListDTO;
+import com.savit.challenge.mapper.ChallengeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ChallengeServiceImpl implements ChallengeService{
+
+    private final ChallengeMapper challengeMapper;
+
+    @Override
+    public List<ChallengeListDTO> getChallengeList() {
+        return challengeMapper.getChallengeList();
+    }
+}

--- a/src/main/java/com/savit/config/ServletConfig.java
+++ b/src/main/java/com/savit/config/ServletConfig.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @ComponentScan(basePackages = {
         "com.savit.user.controller",
         "com.savit.budget.controller",
-        "com.savit.card.controller"
+        "com.savit.card.controller",
+        "com.savit.challenge.controller"
 })public class ServletConfig {
 }

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.savit.challenge.mapper.ChallengeMapper">
+
+    <!--이번주 일요일 까지 참여가능 챌린지들 보여주기 - 챌린지 메인 페이지 -->
+    <select id="getChallengeList" resultType="com.savit.challenge.dto.ChallengeListDTO">
+        select ch.title, ch.start_date, ch.end_date, c.name AS categoryName
+        from challenge as ch
+                 inner join category as c on ch.category_id = c.id
+        where ch.start_date between current_date() AND current_date() + interval (7 - dayofweek(curdate())) day
+        order by ch.start_date asc
+    </select>
+</mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 이번 주 일요일까지 참여 가능한 챌린지 리스트 조회 API 구현

## 🔧 주요 변경 사항
### API 엔드포인트
- `GET /api/challenge` - 챌린지 리스트 조회

### 구현 파일
- **ChallengeListDTO**: 제목, 시작날짜, 끝날짜, 카테고리명 응답 객체
- **ChallengeController**: 챌린지 조회 REST API 컨트롤러  
- **ChallengeService/Impl**: 챌린지 비즈니스 로직 서비스
- **ChallengeMapper**: 챌린지 데이터 접근 매퍼

### 데이터베이스 연동
- Challenge와 Category 테이블 INNER JOIN으로 카테고리명 포함 조회
- 이번 주 일요일까지 시작하는 챌린지만 필터링
- 시작날짜 기준 오름차순 정렬

## 📌 관련 이슈
- closes #51 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함