### PR TITLE
[feat] 카드 상세 조회 및 이미지 링크 저장 기능 구현 (#53, #55)

### DIFF
--- a/src/main/java/com/savit/card/controller/CardController.java
+++ b/src/main/java/com/savit/card/controller/CardController.java
@@ -1,16 +1,14 @@
 package com.savit.card.controller;
 
-import com.savit.card.dto.CardRegisterRequest;
+import com.savit.card.dto.CardDetailResponseDTO;
+import com.savit.card.dto.CardRegisterRequestDTO;
 import com.savit.card.service.CardService;
 import com.savit.security.JwtUtil;
 import com.savit.user.domain.User;
 import com.savit.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 import javax.servlet.http.HttpServletRequest;
@@ -19,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/card")
+@RequestMapping("/api/cards")
 @RequiredArgsConstructor
 public class CardController {
 
@@ -29,7 +27,7 @@ public class CardController {
 
     @PostMapping("/register")
     public ResponseEntity<?> registerCardAndFetch(
-            @RequestBody @Valid CardRegisterRequest req, HttpServletRequest request) {
+            @RequestBody @Valid CardRegisterRequestDTO req, HttpServletRequest request) {
 
         try {
             Long userId = jwtUtil.getUserIdFromToken(request);
@@ -59,4 +57,22 @@ public class CardController {
                     .body(Map.of("error", e.getMessage()));
         }
     }
+
+    @GetMapping("/{cardId}")
+    public ResponseEntity<?> getCardDetail(
+            @PathVariable Long cardId,
+            HttpServletRequest request
+    ) {
+        try {
+            Long userId = jwtUtil.getUserIdFromToken(request);
+
+            CardDetailResponseDTO response = cardService.getCardDetailWithUsage(cardId, userId);
+
+            return ResponseEntity.ok(Map.of("card", response));
+        } catch (Exception e) {
+            return ResponseEntity.status(500)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
 }

--- a/src/main/java/com/savit/card/domain/Card.java
+++ b/src/main/java/com/savit/card/domain/Card.java
@@ -1,11 +1,12 @@
 package com.savit.card.domain;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString(exclude = {"cardPassword", "encryptedCardNo"})
 @Builder
 public class Card {
 
@@ -19,6 +20,7 @@ public class Card {
     private String cardPassword;
     private String resCardType;
     private String resSleepYn;
+    private String resImageLink;
     private LocalDateTime registeredAt;
     private Long userId;
 }

--- a/src/main/java/com/savit/card/dto/CardDetailResponseDTO.java
+++ b/src/main/java/com/savit/card/dto/CardDetailResponseDTO.java
@@ -9,11 +9,13 @@ public class CardDetailResponseDTO {
     private String cardName;
     private String resCardNo;
     private int usageAmount;
+    private String resImageLink;
 
     public CardDetailResponseDTO(Card card, int usageAmount) {
         this.cardId = card.getId();
         this.cardName = card.getCardName();
         this.resCardNo = card.getResCardNo();
         this.usageAmount = usageAmount;
+        this.resImageLink = card.getResImageLink();
     }
 }

--- a/src/main/java/com/savit/card/dto/CardDetailResponseDTO.java
+++ b/src/main/java/com/savit/card/dto/CardDetailResponseDTO.java
@@ -1,0 +1,19 @@
+package com.savit.card.dto;
+
+import com.savit.card.domain.Card;
+import lombok.Getter;
+
+@Getter
+public class CardDetailResponseDTO {
+    private Long cardId;
+    private String cardName;
+    private String resCardNo;
+    private int usageAmount;
+
+    public CardDetailResponseDTO(Card card, int usageAmount) {
+        this.cardId = card.getId();
+        this.cardName = card.getCardName();
+        this.resCardNo = card.getResCardNo();
+        this.usageAmount = usageAmount;
+    }
+}

--- a/src/main/java/com/savit/card/dto/CardRegisterRequestDTO.java
+++ b/src/main/java/com/savit/card/dto/CardRegisterRequestDTO.java
@@ -1,9 +1,11 @@
 package com.savit.card.dto;
 
-import lombok.Data;
+import lombok.*;
 
-@Data
-public class CardRegisterRequest {
+@Getter
+@Setter
+@NoArgsConstructor
+public class CardRegisterRequestDTO {
     private String organization;
     private String loginId;
     private String loginPw;

--- a/src/main/java/com/savit/card/mapper/CardMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardMapper.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Mapper
 public interface CardMapper {
     void insertCards(@Param("cards") List<Card> cards);
+    Card selectCardByIdAndUserId(@Param("cardId") Long cardId, @Param("userId") Long userId);
+    int selectMonthlyUsageAmount(@Param("cardId") Long cardId);
 }

--- a/src/main/java/com/savit/card/service/CardService.java
+++ b/src/main/java/com/savit/card/service/CardService.java
@@ -110,18 +110,6 @@ public class CardService {
                           Long userId,
                           String encryptedCardNo,
                           String cardPassword) {
-// 여기부터
-        for (Map<String, Object> data : cardDataList) {
-            log.info("CODEF 카드 데이터: {}", data);  // 전체 응답 확인
-
-            String cardName = (String) data.get("resCardName");
-            if (cardName == null) {
-                log.warn("⚠️ 카드 이름이 누락된 항목입니다: {}", data);
-            } else {
-                log.info("✅ 카드 이름: {}", cardName);
-            }
-        }
-        // 여기까지
 
         List<Card> cards = cardDataList.stream().map(data -> Card.builder()
                         .connectedId(connectedId)
@@ -139,6 +127,7 @@ public class CardService {
                         .cardPassword(codefUtil.encryptRSA(cardPassword))
                         .registeredAt(LocalDateTime.now())
                         .userId(userId)
+                        .resImageLink((String) data.get("resImageLink"))
                         .build())
                 .toList();
 

--- a/src/main/resources/mapper/card/CardMapper.xml
+++ b/src/main/resources/mapper/card/CardMapper.xml
@@ -35,4 +35,18 @@
             )
         </foreach>
     </insert>
+
+    <select id="selectCardByIdAndUserId" resultType="com.savit.card.domain.Card">
+        SELECT * FROM Card
+        WHERE id = #{cardId}
+          AND user_id = #{userId}
+    </select>
+
+    <select id="selectMonthlyUsageAmount" resultType="int">
+        SELECT COALESCE(SUM(CAST(res_used_amount AS UNSIGNED)), 0)
+        FROM CardTransaction
+        WHERE card_id = #{cardId}
+          AND res_cancel_yn = '0'
+          AND res_used_date LIKE CONCAT(DATE_FORMAT(NOW(), '%Y%m'), '%')
+    </select>
 </mapper>

--- a/src/main/resources/mapper/card/CardMapper.xml
+++ b/src/main/resources/mapper/card/CardMapper.xml
@@ -16,7 +16,8 @@
         res_card_type,
         res_sleep_yn,
         registered_at,
-        user_id
+        user_id,
+        res_image_link
         )
         VALUES
         <foreach collection="cards" item="card" separator=",">
@@ -31,7 +32,8 @@
             #{card.resCardType},
             #{card.resSleepYn},
             #{card.registeredAt},
-            #{card.userId}
+            #{card.userId},
+            #{card.resImageLink}
             )
         </foreach>
     </insert>

--- a/src/test/java/com/savit/card/CardServiceTest.java
+++ b/src/test/java/com/savit/card/CardServiceTest.java
@@ -1,6 +1,6 @@
 package com.savit.card;
 
-import com.savit.card.dto.CardRegisterRequest;
+import com.savit.card.dto.CardRegisterRequestDTO;
 import com.savit.card.mapper.CardMapper;
 import com.savit.card.service.CardService;
 import com.savit.card.service.CodefTokenService;
@@ -34,7 +34,7 @@ class CardServiceTest {
 
     @Test
     void registerAccount_정상응답_connectedId_반환() throws Exception {
-        CardRegisterRequest req = new CardRegisterRequest();
+        CardRegisterRequestDTO req = new CardRegisterRequestDTO();
         req.setLoginId("testId");
         req.setLoginPw("testPw");
         req.setBirthDate("19900101");
@@ -56,7 +56,7 @@ class CardServiceTest {
 
     @Test
     void registerAccount_connectedId없을경우_예외발생() throws Exception {
-        CardRegisterRequest req = new CardRegisterRequest();
+        CardRegisterRequestDTO req = new CardRegisterRequestDTO();
         req.setLoginId("id");
         req.setLoginPw("pw");
         req.setBirthDate("19900101");


### PR DESCRIPTION
## ✅ 작업 내용
- 카드 ID를 기반으로 카드 상세 정보 및 월간 사용 금액을 조회하는 API 구현
- JWT 토큰을 통해 사용자 식별 후 카드 소유 여부 확인
- 응답에 카드 이름, 카드 번호, 이번 달 총 사용 금액 포함
- CODEF 카드 리스트 응답에 포함된 `resImageLink`를 저장 및 응답 포함

## 🔧 주요 변경 사항
- `CardDetailResponseDTO.java` 생성
- `CardController.java`에 GET `/api/cards/{cardId}` 추가
- `CardMapper.xml` 및 `CardMapper.java`에 카드 조회, 월간 금액 합계 쿼리 추가
- `CardService.java`에 상세 조회 로직 추가
- `CardServiceTest.java`에 테스트 메서드 추가
- 기존 `CardRegisterRequest` → `CardRegisterRequestDTO`로 이름 변경
- `Card` 도메인에 `resImageLink` 필드 추가
- `card` 테이블에 `res_image_link` 컬럼 추가 (`VARCHAR(255)`)
- `saveCards` 메서드 내 `.resImageLink((String) data.get("resImageLink"))` 적용
- 카드 상세 응답에 이미지 URL 포함

## 📌 관련 이슈
- closes #53 
- closes #55 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 단위 테스트 통과 확인
- [x] JWT 기반 사용자 인증 정상 작동
- [x] 카드가 없거나 소유하지 않은 경우 예외 처리 완료
- [x] 카드 이미지 URL 저장 및 조회 기능 정상 동작