### PR TITLE
[feat] 카드 등록 요청 DTO에 기관코드 유효성 검증 추가 (#57)

### DIFF
--- a/src/main/java/com/savit/card/dto/CardRegisterRequestDTO.java
+++ b/src/main/java/com/savit/card/dto/CardRegisterRequestDTO.java
@@ -2,10 +2,13 @@ package com.savit.card.dto;
 
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
+
 @Getter
 @Setter
 @NoArgsConstructor
 public class CardRegisterRequestDTO {
+    @NotBlank(message = "기관코드는 필수입니다.")
     private String organization;
     private String loginId;
     private String loginPw;


### PR DESCRIPTION
## ✅ 작업 내용
- 카드 등록 요청 DTO에 기관코드 유효성 검증 어노테이션 추가

## 🔧 주요 변경 사항
- `CardRegisterRequestDTO` 클래스
  - `organization` 필드에 `@NotBlank` 추가

## 📌 관련 이슈
- closes #57 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함