### PR TITLE
[chore] Swagger v2 API 문서 경로 설정 추가 (#60)

### DIFF
--- a/src/main/java/com/savit/config/WebConfig.java
+++ b/src/main/java/com/savit/config/WebConfig.java
@@ -74,6 +74,8 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
             public void addResourceHandlers(ResourceHandlerRegistry registry) {
                 registry.addResourceHandler("swagger-ui.html")
                         .addResourceLocations("classpath:/META-INF/resources/");
+                registry.addResourceHandler("/v2/api-docs")
+                        .addResourceLocations("classpath:/META-INF/resources/");
                 registry.addResourceHandler("/webjars/**")
                         .addResourceLocations("classpath:/META-INF/resources/webjars/");
             }


### PR DESCRIPTION
## ✅ 작업 내용
- Swagger UI에서 `/v2/api-docs` 접근 가능하도록 설정 추가

## 🔧 주요 변경 사항
- `WebConfig#addResourceHandlers()`에 다음 경로 추가:
  ```java
  registry.addResourceHandler("/v2/api-docs")
          .addResourceLocations("classpath:/META-INF/resources/");

## 📌 관련 이슈
closes #60 