### PR TITLE
[feat] jwt 토큰 redirect url 에 보내는 기능 구현 (#65)

### DIFF
--- a/src/main/java/com/savit/config/WebConfig.java
+++ b/src/main/java/com/savit/config/WebConfig.java
@@ -63,7 +63,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:5173")
+                        .allowedOriginPatterns("*")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*")
                         .exposedHeaders("Authorization")

--- a/src/main/java/com/savit/security/JwtTokenProvider.java
+++ b/src/main/java/com/savit/security/JwtTokenProvider.java
@@ -23,9 +23,7 @@ public class JwtTokenProvider {
     @Value("${jwt.refresh-token-expiration}")
     private long refreshTokenValidityInMilliseconds; // 7일
 
-    /**
-     * Access Token 생성
-     */
+    // access token 생성
     public String createAccessToken(String userId) {
         Claims claims = Jwts.claims().setSubject(userId);
         // 토큰 타입 구분
@@ -42,9 +40,8 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    /**
-     * Refresh Token 생성
-     */
+
+    // refresh token 생성
     public String createRefreshToken(String userId) {
         Claims claims = Jwts.claims().setSubject(userId);
         claims.put("type", "refresh"); // 토큰 타입 구분
@@ -60,9 +57,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    /**
-     * Access Token과 Refresh Token 동시 생성
-     */
+    // refresh & access token 동시 생성
     public TokenPairDTO createTokenPair(String userId) {
         String accessToken = createAccessToken(userId);
         String refreshToken = createRefreshToken(userId);
@@ -73,9 +68,7 @@ public class JwtTokenProvider {
                 .build();
     }
 
-    /**
-     * 토큰에서 사용자 ID 추출
-     */
+   // 토큰에서 userid 추출
     public String getUserId(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey)
@@ -84,9 +77,7 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    /**
-     * 토큰 유효성 검증
-     */
+    // 토큰 유효성 검증
     public boolean validateToken(String token) {
         try {
             Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
@@ -96,9 +87,7 @@ public class JwtTokenProvider {
         }
     }
 
-    /**
-     * Access Token인지 확인
-     */
+    // access token 인지 확인
     public boolean isAccessToken(String token) {
         try {
             Claims claims = Jwts.parser()
@@ -111,9 +100,7 @@ public class JwtTokenProvider {
         }
     }
 
-    /**
-     * Refresh Token인지 확인
-     */
+    // refresh token 인지 확인
     public boolean isRefreshToken(String token) {
         try {
             Claims claims = Jwts.parser()
@@ -126,9 +113,7 @@ public class JwtTokenProvider {
         }
     }
 
-    /**
-     * 토큰 만료시간 확인
-     */
+   // 토큰 만료 시간
     public Date getExpirationDate(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey)
@@ -137,9 +122,7 @@ public class JwtTokenProvider {
                 .getExpiration();
     }
 
-    /**
-     * 토큰이 곧 만료되는지 확인 (30분 이내)
-     */
+    // 토큰이 곧 만료되는지(30분)
     public boolean isTokenExpiringSoon(String token) {
         try {
             Date expiration = getExpirationDate(token);


### PR DESCRIPTION
## ✅ 작업 내용
카카오 소셜로그인 네트워크 환경 통일 (IP 불일치로 인한 ERR_CONNECTION_TIMED_OUT 해결)
프론트엔드와 백엔드 간 OAuth 콜백 플로우 정상화

## 🔧 주요 변경 사항
AuthController: redirectUrl을 로컬 환경에 맞게 변경 (10.10.0.76 → 10.10.0.58)
카카오 개발자 콘솔: Web 도메인 및 Redirect URI를 통일된 IP로 설정
CORS 설정: allowedOriginPatterns 추가로 개발 환경 유연성 확보

## 📌 관련 이슈
- closes #65 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함