### PR TITLE
feat: 챌린지 참여 조건 검사 및 상세페이지 조회 기능 구현 (#69)

### DIFF
--- a/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
@@ -4,7 +4,9 @@ import com.savit.card.domain.CardTransactionVO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface CardTransactionMapper {
@@ -22,4 +24,11 @@ public interface CardTransactionMapper {
 
     boolean isOwnedByUser(@Param("transactionId") Long transactionId,
                           @Param("userId") Long userId);
+
+
+    // 챌린지 참여 조건 검사
+    // 1) 금액 기준: type = AMOUNT
+    BigDecimal sumAmountByParams (Map<String, Object> params);
+    // 2) 횟수 기준: type = COUNT
+    Long countByParams(Map<String, Object> params);
 }

--- a/src/main/java/com/savit/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/savit/challenge/controller/ChallengeController.java
@@ -1,5 +1,6 @@
 package com.savit.challenge.controller;
 
+import com.savit.challenge.dto.ChallengeDetailDTO;
 import com.savit.challenge.dto.ChallengeListDTO;
 import com.savit.challenge.service.ChallengeService;
 
@@ -7,9 +8,7 @@ import com.savit.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -28,5 +27,12 @@ public class ChallengeController {
         Long userId = jwtUtil.getUserIdFromToken(request);
         List<ChallengeListDTO> result = challengeService.getChallengeList(userId);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{challenge_id}")
+    public ResponseEntity<ChallengeDetailDTO> getChallengeDetail(@PathVariable Long challenge_id, HttpServletRequest request) {
+        Long userId = jwtUtil.getUserIdFromToken(request);
+        ChallengeDetailDTO result = challengeService.getChallengeDetail(challenge_id, userId);
+                return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/savit/challenge/domain/ChallengeVO.java
+++ b/src/main/java/com/savit/challenge/domain/ChallengeVO.java
@@ -1,0 +1,21 @@
+package com.savit.challenge.domain;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Data
+public class ChallengeVO {
+    private Long id;
+    private String title;
+    private String description;
+    private String startDate;
+    private String endDate;
+    private BigDecimal entryFee;
+    private int targetCount;
+    private BigDecimal targetAmount;
+    private String type;
+    private int durationWeeks;
+    private Long categoryId;
+}

--- a/src/main/java/com/savit/challenge/dto/ChallengeDetailDTO.java
+++ b/src/main/java/com/savit/challenge/dto/ChallengeDetailDTO.java
@@ -1,0 +1,23 @@
+package com.savit.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChallengeDetailDTO {
+    private String title;
+    private String description;
+    private String startDate;
+    private String endDate;
+    private BigDecimal entryFee;
+    private String categoryName;
+    private int eligibility;
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
@@ -1,5 +1,6 @@
 package com.savit.challenge.mapper;
 
+import com.savit.challenge.domain.ChallengeVO;
 import com.savit.challenge.dto.ChallengeListDTO;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -7,7 +8,11 @@ import java.util.List;
 
 @Mapper
 public interface ChallengeMapper {
+    // 리스트 조회
     List<Long> findSuccessfulWeeklyCategories(Long userId);
     List<ChallengeListDTO> findWeeklyChallenges();
     List<ChallengeListDTO> findMonthlyChallenges(Long categoryid);
+
+    // 상세조회
+    ChallengeVO findById(Long id);
 }

--- a/src/main/java/com/savit/challenge/service/ChallengeService.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeService.java
@@ -1,9 +1,14 @@
 package com.savit.challenge.service;
 
+import com.savit.challenge.domain.ChallengeVO;
+import com.savit.challenge.dto.ChallengeDetailDTO;
 import com.savit.challenge.dto.ChallengeListDTO;
 
 import java.util.List;
 
 public interface ChallengeService {
     List<ChallengeListDTO> getChallengeList(Long userId);
+    ChallengeDetailDTO getChallengeDetail(Long challengeId, Long userId);
+    int checkEligibility(ChallengeVO vo, Long userId);
+
 }

--- a/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
@@ -1,5 +1,11 @@
 package com.savit.challenge.service;
 
+import com.savit.budget.domain.CategoryVO;
+import com.savit.budget.mapper.CategoryMapper;
+import com.savit.card.mapper.CardApprovalMapper;
+import com.savit.card.mapper.CardTransactionMapper;
+import com.savit.challenge.domain.ChallengeVO;
+import com.savit.challenge.dto.ChallengeDetailDTO;
 import com.savit.challenge.dto.ChallengeListDTO;
 import com.savit.challenge.mapper.ChallengeMapper;
 import lombok.RequiredArgsConstructor;
@@ -7,29 +13,105 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
-public class ChallengeServiceImpl implements ChallengeService{
+public class ChallengeServiceImpl implements ChallengeService {
+
 
     private final ChallengeMapper challengeMapper;
+    private final CategoryMapper categoryMapper;
+    private final CardApprovalMapper cardMapper;
+    private final CardTransactionMapper cardTransactionMapper;
 
+    // 리스트 조회
     @Override
     public List<ChallengeListDTO> getChallengeList(Long userId) {
-            List<Long> categoryids = challengeMapper.findSuccessfulWeeklyCategories(userId);
+        List<Long> categoryids = challengeMapper.findSuccessfulWeeklyCategories(userId);
 
-            List<ChallengeListDTO> weeklyList = challengeMapper.findWeeklyChallenges();
+        List<ChallengeListDTO> weeklyList = challengeMapper.findWeeklyChallenges();
 
-            if(!categoryids.isEmpty()) {
-                for (Long categoryid : categoryids) {
-                    List<ChallengeListDTO> monthlyList = challengeMapper.findMonthlyChallenges(categoryid);
-                    weeklyList.addAll(monthlyList);
-                }
+        if (!categoryids.isEmpty()) {
+            for (Long categoryid : categoryids) {
+                List<ChallengeListDTO> monthlyList = challengeMapper.findMonthlyChallenges(categoryid);
+                weeklyList.addAll(monthlyList);
             }
+        }
 
-            return weeklyList;
+        return weeklyList;
+    }
+
+    // 상세조회
+    @Override
+    public ChallengeDetailDTO getChallengeDetail(Long challengeId, Long userId) {
+        // 1. challenge_id로 챌린지 정보 가져오기
+        ChallengeVO challengeVO = challengeMapper.findById(challengeId);
+        if (challengeVO == null) {
+            throw new RuntimeException("챌린지 없음");
+        }
+
+        // 2. challengeVO로 카테고리 정보 가져오기
+        CategoryVO categoryVO = categoryMapper.findById(challengeVO.getCategoryId());
+        if (categoryVO == null) {
+            throw new RuntimeException("카테고리 없음");
+        }
+
+        // 3. 조건검사: 1/0
+        int eligibility = checkEligibility(challengeVO, userId);
+
+        // 4. 이제 response 타입인 challengeDetailDTO로 변환해주기
+        return ChallengeDetailDTO.builder()
+                .title(challengeVO.getTitle())
+                .description(challengeVO.getDescription())
+                .startDate(challengeVO.getStartDate().toString())
+                .endDate(challengeVO.getEndDate().toString())
+                .entryFee(challengeVO.getEntryFee())
+                .categoryName(categoryVO.getName())
+                .eligibility(eligibility).build();
+    }
+
+    // 조건검사. 결과 참가 가능이면 1, 아니면 0 반환
+    @Override
+    public int checkEligibility(ChallengeVO vo, Long userId) {
+
+        // 1. userId로 사용자 카드(들) 가져오기
+        List<Long> cardIds = cardMapper.findCardIdsByUser(userId);
+        if (cardIds.isEmpty()) {
+            return 0;
+        }
+
+        // 2. 기간 계산( 1주 챌린지 -> 3주 / 4주 챌린지 -> 12주)
+        int previousWeeks = vo.getDurationWeeks() == 1 ? 3 : 12;
+
+        // 3. 파라미터 설정
+        Map<String, Object> params = new HashMap<>();
+        params.put("cardIds", cardIds);
+        params.put("categoryId", vo.getCategoryId());
+        params.put("previousWeeks", previousWeeks);
+
+            // 금액 기준 - type: AMOUNT
+        if("AMOUNT".equals(vo.getType())) {
+            BigDecimal totalAmount = cardTransactionMapper.sumAmountByParams(params);
+            if (totalAmount == null) totalAmount = BigDecimal.ZERO;
+
+            BigDecimal baselineAmount = vo.getTargetAmount().multiply(new BigDecimal("3"));
+            return totalAmount.compareTo(baselineAmount) > 0 ? 1 : 0;
+
+            // 횟수 기준 - type: COUNT
+        } else if ("COUNT".equals(vo.getType())) {
+            Long totalCount = cardTransactionMapper.countByParams(params);
+            if (totalCount == null ) totalCount = 0L;
+
+            Long baselineCount = (long) (vo.getTargetCount() * 3);
+            return totalCount > baselineCount ? 1: 0;
+
+        }
+        return 0;
     }
 }

--- a/src/main/resources/mapper/card/CardTransactionMapper.xml
+++ b/src/main/resources/mapper/card/CardTransactionMapper.xml
@@ -50,4 +50,30 @@
         )
     </select>
 
+    <!--금액 합계 조회: sum()-->
+    <select id="sumAmountByParams" parameterType="map" resultType="java.math.BigDecimal">
+        SELECT COALESCE(SUM(CAST(res_used_amount AS DECIMAL(12,2))), 0)
+        FROM CardTransaction
+        WHERE card_id IN
+        <foreach collection="cardIds" item="cardId" open="(" separator="," close=")">
+            #{cardId}
+        </foreach>
+        AND category_id = #{categoryId}
+        AND STR_TO_DATE(res_used_date, '%Y%m%d') >= DATE_SUB(NOW(), INTERVAL #{previousWeeks} WEEK)
+        AND (res_cancel_yn IS NULL OR res_cancel_yn != 'Y')
+    </select>
+
+    <!-- 거래 횟수 조회: count(*) -->
+    <select id="countByParams" parameterType="map" resultType="Long">
+        SELECT COUNT(*)
+        FROM CardTransaction
+        WHERE card_id IN
+        <foreach collection="cardIds" item="cardId" open="(" separator="," close=")">
+            #{cardId}
+        </foreach>
+        AND category_id = #{categoryId}
+        AND STR_TO_DATE(res_used_date, '%Y%m%d') >= DATE_SUB(NOW(), INTERVAL #{previousWeeks} WEEK)
+        AND (res_cancel_yn IS NULL OR res_cancel_yn != 'Y')
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -8,7 +8,7 @@
         from challengeparticipation as cp
                  inner join challenge as c on cp.challenge_id = c.id
         where cp.user_id = #{userId}
-          and cp.status = 'success'
+          and cp.status = 'SUCCESS'
           and c.duration_weeks = 1
     </select>
 
@@ -35,6 +35,22 @@
         order by c.start_date asc
 
 
+    </select>
+    <select id="findById" resultType="com.savit.challenge.domain.ChallengeVO">
+
+        select id,
+               title,
+               description,
+               start_date,
+               end_date,
+               entry_fee,
+               target_count,
+               target_amount,
+               type,
+               duration_weeks,
+               category_id
+        from challenge
+        where id = #{id}
     </select>
 
 


### PR DESCRIPTION
## ✅ 작업 내용

- 개별 챌린지의 기간, 카테고리, 종류에 따라 조건 검사 후 
- 개별 챌린지 상세 페이지 조회 기능 구현

## 🔧 주요 변경 사항
- ChallengVO
- ChallengeDetailDTO: 상세페이지 반환값
- ChallengeController: GetMapping("/api/challenge/{challenge_id}")
- ChallengeService/Impl: **getChallengeDetail**(상세페이지 조회), **checkEligibility**(조건 검사로직)
- ChallengeMapper: **findById**
- CardTransactionMapper: 조건 검사 위한 거래 내역 파악 쿼리.**sumAmountByParams**, **countByParams**
- CategoryMapper의 **findById**, CardApprovalMapper의 **findCardIdsByUser** 사용

## 📌 관련 이슈
- closes #69 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함