### PR TITLE
[ci] dev 브랜치에 push 시 CI/CD 트리거되도록 설정 변경 (#78)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@ name: Savit Server CI/CD with Docker
 
 on:
   push:
-    branches: ['test/cicd'] # main 브랜치에 push할 때 실행 (현재 팀 레포상 dev 브랜치에서 트리거 되게끔)
+    branches: ['dev'] # main 브랜치에 push할 때 실행 (현재 팀 레포상 dev 브랜치에서 트리거 되게끔)
 
 jobs:
   deploy:


### PR DESCRIPTION
## 🧹 작업 개요
CI/CD 트리거 브랜치 설정 변경

## 🛠 변경 항목
- `.github/workflows/gradle.yml` 내 trigger 대상 브랜치를 `test/cicd` → `dev`로 수정

## 📌 작업 이유
- main 브랜치 역할을 하는 `dev`에 push할 때 CI/CD가 실행되어야 하나, 기존 설정은 테스트 브랜치에만 동작하도록 되어 있었음

## 📌 관련 이슈
- closes #78 

## ✅ 체크리스트
- [x] CI/CD 트리거 브랜치 설정 변경 확인
- [x] 기존 워크플로우와 충돌 없음