### PR TITLE
[feat] Firebase FCM 연동 기본 설정 및 gradle 의존성 추가 (#56)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,10 @@ build/
 # pem File
 *.pem
 
+# Firebase Service Account Keys
+src/main/resources/firebase/
+*firebase*.json
+*service-account*.json
+
 # macOS
 .DS_Store.gradle/
-
-gradle/wrapper/gradle-wrapper.jar
-gradle/wrapper/gradle-wrapper.properties
-gradlew
-gradlew.bat

--- a/build.gradle
+++ b/build.gradle
@@ -83,12 +83,18 @@ dependencies {
     // Codef
     implementation 'io.codef.api:easycodef-java:1.0.6'
 
+    // Firebase Admin SDK
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
     // Test
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     testImplementation "org.springframework:spring-test:${springVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+    // 비동기 작업 완료 기다리는 테스트 코드에 사용
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 
     // Mokito
     testImplementation 'org.mockito:mockito-core:5.12.0'

--- a/logback-spring.xml
+++ b/logback-spring.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    
+    <!-- 콘솔 출력 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    
+    <!-- 파일 출력 (스케줄러 전용) -->
+    <appender name="SCHEDULER_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/scheduler.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/scheduler.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+    
+    <!-- 스케줄러 관련 로그를 별도 파일로 -->
+    <logger name="com.savit.scheduler" level="INFO" additivity="false">
+        <appender-ref ref="SCHEDULER_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    
+    <!-- 카드 승인 서비스 로그 -->
+    <logger name="com.savit.card.service" level="INFO" additivity="false">
+        <appender-ref ref="SCHEDULER_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    
+    <!-- 예산 모니터링 서비스 로그 -->
+    <logger name="com.savit.budget.service" level="INFO" additivity="false">
+        <appender-ref ref="SCHEDULER_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    
+    <!-- 알림 서비스 로그 -->
+    <logger name="com.savit.notification.service" level="INFO" additivity="false">
+        <appender-ref ref="SCHEDULER_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    
+    <!-- 루트 로거 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+    
+</configuration>

--- a/src/main/java/com/savit/config/FirebaseConfig.java
+++ b/src/main/java/com/savit/config/FirebaseConfig.java
@@ -1,0 +1,73 @@
+package com.savit.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Firebase Admin SDK 설정
+ * 공식 문서: https://firebase.google.com/docs/cloud-messaging/server
+ */
+@Slf4j
+@Configuration
+public class FirebaseConfig  {
+
+    @Value("${firebase.config.path}")
+    private String firebaseConfigPath;
+
+    /**
+     * Firebase App 초기화
+     * Firebase Admin SDK의 진입점
+     */
+    @Bean
+    public FirebaseApp firebaseApp() {
+        try {
+            if(FirebaseApp.getApps().isEmpty()) {
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(
+                                GoogleCredentials.fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                        )
+                        .build();
+
+                log.info("firebase app 초기화 완료");
+                return FirebaseApp.initializeApp(options);
+            } else {
+                // 이미 파베 앱 만들어졌으면 기존의 디폴트 앱 가져와서 반환
+                return FirebaseApp.getInstance();
+            }
+
+
+        } catch (IOException exception) {
+            log.error("firebase app 초기화 실패 {}", exception.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * FirebaseMessaging Bean 생성
+     * FCM 메시지 전송을 위한 인스턴스임!
+     */
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        try {
+            return FirebaseMessaging.getInstance(firebaseApp);
+        } catch (Exception e) {
+            log.warn("FirebaseMessaging 인스턴스 생성 실패: {}", e.getMessage());
+            return null; // null을 반환하여 서비스에서 체크할 수 있도록 함
+        }
+    }
+
+}


### PR DESCRIPTION
- Firebase Admin SDK 의존성 추가
- FirebaseConfig 설정 클래스 구현
- 서비스 계정 키 기반 Firebase 초기화
- FirebaseMessaging Bean 등록

## ✅ 작업 내용
- 어떤 작업을 했는지 간단히 요약

## 🔧 주요 변경 사항
  - Firebase Admin SDK 9.2.0 의존성 추가
  - Firebase 서비스 계정 키 파일 보안을 위한 gitignore 설정
  - FirebaseConfig 클래스로 Firebase 앱 초기화 및 FCM Bean 등록
  - 스케줄러 및 알림 서비스 전용 로깅 설정 구현

## 🔧 기술적 세부사항
  - Google Credentials 기반 Firebase 초기화
  - FirebaseApp 중복 생성 방지 로직 구현

## 📌 관련 이슈
- closes #56 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] FirebaseApp Bean 정상 등록 확인
- [x] FirebaseMessaging Bean 정상 등록 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함