### PR TITLE
[feat] FCM 알림 도메인 및 매퍼 구현 (#71)

### DIFF
--- a/src/main/java/com/savit/notification/domain/NotificationType.java
+++ b/src/main/java/com/savit/notification/domain/NotificationType.java
@@ -1,0 +1,56 @@
+package com.savit.notification.domain;
+
+/**
+ * 푸시 알림 타입 정의
+ */
+public enum NotificationType {
+
+    /** 예산 초과 알림 */
+    BUDGET_EXCEEDED("budget_exceeded", "예산 초과"),
+
+    /** 카테고리별 예산 경고 (80% 사용 시) */
+    CATEGORY_WARNING("category_warning", "카테고리 예산 경고"),
+
+    /** 카드 사용 즉시 알림 */
+    CARD_USAGE("card_usage", "카드 사용 알림"),
+
+    /** 랜덤 잔소리 알림 */
+    RANDOM_NAGGING("random_nagging", "랜덤 잔소리"),
+
+    /** 일일 리포트 알림 */
+    DAILY_REPORT("daily_report", "일일 리포트"),
+
+    /** 월간 리포트 알림 */
+    MONTHLY_REPORT("monthly_report", "월간 리포트"),
+
+    /** 목표 달성 알림 */
+    GOAL_ACHIEVED("goal_achieved", "목표 달성"),
+
+    /** 시스템 공지 알림 */
+    SYSTEM_NOTICE("system_notice", "시스템 공지");
+
+    private final String code;
+    private final String description;
+
+    NotificationType(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static NotificationType fromCode(String code) {
+        for (NotificationType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown notification type code: " + code);
+    }
+}

--- a/src/main/java/com/savit/notification/domain/PushNotification.java
+++ b/src/main/java/com/savit/notification/domain/PushNotification.java
@@ -1,0 +1,18 @@
+package com.savit.notification.domain;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class PushNotification {
+    private Long id;
+    private Long userId;
+    private String fcmToken;
+    private String title;
+    private String body;
+    private String type;
+    private String status; // PENDING, SENT, FAILED
+    private LocalDateTime createdAt;
+    private LocalDateTime sentAt;
+    private String errorMessage;
+}

--- a/src/main/java/com/savit/notification/domain/UserFcmToken.java
+++ b/src/main/java/com/savit/notification/domain/UserFcmToken.java
@@ -1,0 +1,15 @@
+package com.savit.notification.domain;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class UserFcmToken {
+    private Long id;
+    private Long userId;
+    private String fcmToken;
+    private String deviceType; // WEB, ANDROID, IOS
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/savit/notification/dto/FcmTokenRequest.java
+++ b/src/main/java/com/savit/notification/dto/FcmTokenRequest.java
@@ -1,0 +1,9 @@
+package com.savit.notification.dto;
+
+import lombok.Data;
+
+@Data
+public class FcmTokenRequest {
+    private String fcmToken;
+    private String deviceType;
+}

--- a/src/main/java/com/savit/notification/dto/PushNotificationRequest.java
+++ b/src/main/java/com/savit/notification/dto/PushNotificationRequest.java
@@ -1,0 +1,23 @@
+package com.savit.notification.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushNotificationRequest {
+    private String token;
+    private String title;
+    private String body;
+    private String image;
+    private Map<String, String> data;
+
+    public PushNotificationRequest(String token, String title, String body) {
+        this.token = token;
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/main/java/com/savit/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/savit/notification/mapper/NotificationMapper.java
@@ -1,0 +1,26 @@
+package com.savit.notification.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import com.savit.notification.domain.PushNotification;
+import com.savit.notification.domain.UserFcmToken;
+
+import java.util.List;
+
+@Mapper
+public interface NotificationMapper {
+
+    void insertNotification(PushNotification notification);
+
+    void insertUserFcmToken(@Param("userId") Long userId,
+                            @Param("fcmToken") String fcmToken,
+                            @Param("deviceType") String deviceType);
+
+    void deactivateUserTokens(@Param("userId") Long userId,
+                              @Param("deviceType") String deviceType);
+
+    List<UserFcmToken> findActiveTokensByUserId(@Param("userId") Long userId);
+
+    UserFcmToken findTokenByUserIdAndDeviceType(@Param("userId") Long userId,
+                                                @Param("deviceType") String deviceType);
+}

--- a/src/main/resources/mapper/notification/NotificationMapper.xml
+++ b/src/main/resources/mapper/notification/NotificationMapper.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.savit.notification.mapper.NotificationMapper">
+
+    <resultMap id="PushNotificationResult" type="com.savit.notification.domain.PushNotification">
+        <id property="id" column="id"/>
+        <result property="userId" column="user_id"/>
+        <result property="fcmToken" column="fcm_token"/>
+        <result property="title" column="title"/>
+        <result property="body" column="body"/>
+        <result property="type" column="type"/>
+        <result property="status" column="status"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="sentAt" column="sent_at"/>
+        <result property="errorMessage" column="error_message"/>
+    </resultMap>
+
+    <resultMap id="UserFcmTokenResult" type="com.savit.notification.domain.UserFcmToken">
+        <id property="id" column="id"/>
+        <result property="userId" column="user_id"/>
+        <result property="fcmToken" column="fcm_token"/>
+        <result property="deviceType" column="device_type"/>
+        <result property="isActive" column="is_active"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <!-- 푸시 알림 이력 저장 -->
+    <insert id="insertNotification" parameterType="com.savit.notification.domain.PushNotification">
+        INSERT INTO PushNotifications (
+            user_id, fcm_token, title, body, type, status,
+            created_at, sent_at, error_message
+        ) VALUES (
+                     #{userId}, #{fcmToken}, #{title}, #{body}, #{type}, #{status},
+                     #{createdAt}, #{sentAt}, #{errorMessage}
+                 )
+    </insert>
+
+    <!-- 사용자 FCM 토큰 저장 -->
+    <insert id="insertUserFcmToken">
+        INSERT INTO UserFcmTokens (
+            user_id, fcm_token, device_type, is_active, created_at, updated_at
+        ) VALUES (
+                     #{userId}, #{fcmToken}, #{deviceType}, TRUE, NOW(), NOW()
+                 )
+    </insert>
+
+    <!-- 기존 토큰 비활성화 -->
+    <update id="deactivateUserTokens">
+        UPDATE UserFcmTokens
+        SET is_active = FALSE, updated_at = NOW()
+        WHERE user_id = #{userId}
+          AND device_type = #{deviceType}
+          AND is_active = TRUE
+    </update>
+
+    <!-- 사용자의 활성 토큰 조회 -->
+    <select id="findActiveTokensByUserId" resultMap="UserFcmTokenResult">
+        SELECT id, user_id, fcm_token, device_type, is_active, created_at, updated_at
+        FROM UserFcmTokens
+        WHERE user_id = #{userId}
+          AND is_active = TRUE
+        ORDER BY updated_at DESC
+    </select>
+
+    <!-- 특정 디바이스 타입의 토큰 조회 -->
+    <select id="findTokenByUserIdAndDeviceType" resultMap="UserFcmTokenResult">
+        SELECT id, user_id, fcm_token, device_type, is_active, created_at, updated_at
+        FROM UserFcmTokens
+        WHERE user_id = #{userId}
+          AND device_type = #{deviceType}
+          AND is_active = TRUE
+        ORDER BY updated_at DESC
+        LIMIT 1
+    </select>
+
+</mapper>


### PR DESCRIPTION
## ✅ 작업 내용
  - FCM 알림 도메인 및 매퍼 구현
  - 알림 타입별 enum 관리 (OVER_BUDGET, TOP_SPENDING, DROPOUT)
  - 디바이스별 FCM 토큰 중복 관리 방지
  - 알림 발송 이력 및 실패 로그 저장

## 🔧 주요 변경 사항
  - FCM 알림 발송 이력 관리용 도메인 객체 구현
  - 사용자별 FCM 토큰 관리용 도메인 객체 구현
  - FCM 요청/응답 처리용 DTO 객체 구현
  - MyBatis 기반 데이터 접근 계층 구현

## 📌 관련 이슈
- closes #71 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 도메인 객체 필드 매핑 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함