### PR TITLE
[feat] 사용자 카드 목록 조회 API 추가(#89)

### DIFF
--- a/src/main/java/com/savit/card/controller/CardController.java
+++ b/src/main/java/com/savit/card/controller/CardController.java
@@ -75,4 +75,16 @@ public class CardController {
         }
     }
 
+    @GetMapping
+    public ResponseEntity<?> getUserCardList(HttpServletRequest request) {
+        try {
+            Long userId = jwtUtil.getUserIdFromToken(request);
+            List<CardDetailResponseDTO> cardList = cardService.getCardListByUser(userId);
+            return ResponseEntity.ok(Map.of("cards", cardList));
+        } catch (Exception e) {
+            return ResponseEntity.status(500)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
 }

--- a/src/main/java/com/savit/card/mapper/CardMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardMapper.java
@@ -11,4 +11,5 @@ public interface CardMapper {
     void insertCards(@Param("cards") List<Card> cards);
     Card selectCardByIdAndUserId(@Param("cardId") Long cardId, @Param("userId") Long userId);
     int selectMonthlyUsageAmount(@Param("cardId") Long cardId);
+    List<Card> selectCardsByUserId(Long userId);
 }

--- a/src/main/java/com/savit/card/service/CardService.java
+++ b/src/main/java/com/savit/card/service/CardService.java
@@ -142,4 +142,14 @@ public class CardService {
 
         return new CardDetailResponseDTO(card, usageAmount);
     }
+
+    public List<CardDetailResponseDTO> getCardListByUser(Long userId) {
+        List<Card> cards = cardMapper.selectCardsByUserId(userId);
+
+        return cards.stream().map(card -> {
+            int usageAmount = cardMapper.selectMonthlyUsageAmount(card.getId());
+            return new CardDetailResponseDTO(card, usageAmount);
+        }).toList();
+    }
+
 }

--- a/src/main/resources/mapper/card/CardMapper.xml
+++ b/src/main/resources/mapper/card/CardMapper.xml
@@ -44,6 +44,11 @@
           AND user_id = #{userId}
     </select>
 
+    <select id="selectCardsByUserId" resultType="com.savit.card.domain.Card">
+        SELECT * FROM card
+        WHERE user_id = #{userId}
+    </select>
+
     <select id="selectMonthlyUsageAmount" resultType="int">
         SELECT COALESCE(SUM(CAST(res_used_amount AS UNSIGNED)), 0)
         FROM CardTransaction


### PR DESCRIPTION
## ✅ 작업 내용
사용자 보유 카드 목록 조회 API를 추가했습니다.

## 🔧 주요 변경 사항
- **CardService.java**: `getCardListByUser(Long userId)` 메서드 추가
  - 사용자 ID로 카드 목록 조회 및 월간 사용량 정보 포함 반환
- **CardController.java**: `GET /api/cards` 엔드포인트 추가
  - JWT 토큰에서 사용자 ID 추출하여 카드 목록 조회
  - 에러 핸들링 포함 (500 상태코드 및 에러 메시지 반환)

## 📌 관련 이슈
- closes #89 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함

## 📝 추가 정보
- 기존 `getCardDetailWithUsage` 메서드와 동일한 로직을 사용하여 일관성 유지
- 에러 발생 시 상세한 에러 메시지를 클라이언트에 전달하도록 구현
- JWT 인증이 필요한 API로, 토큰 없이 호출 시 401 에러 발생 예상