### PR TITLE
[feat] 카드 승인내역 자동 동기화 및 사용자 알림을 위한 스케줄러 시스템 구현 (#76)

### DIFF
--- a/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
+++ b/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
@@ -1,0 +1,221 @@
+package com.savit.scheduler.controller;
+
+import com.savit.budget.service.BudgetMonitoringService;
+import com.savit.card.dto.BudgetMonitoringDTO;
+import com.savit.card.service.AsyncCardApprovalService;
+import com.savit.card.service.CardApprovalService;
+import com.savit.notification.service.NotificationService;
+import com.savit.scheduler.job.CardApprovalScheduler;
+import com.savit.scheduler.job.RandomNaggingScheduler;
+import com.savit.user.mapper.UserMapper;
+import com.savit.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 스케줄러 테스트용 컨트롤러
+ * 실제 스케줄러 동작을 수동으로 테스트하기 위한 API 제공
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/test/scheduler")
+@RequiredArgsConstructor
+public class SchedulerTestController {
+
+    private final CardApprovalScheduler cardApprovalScheduler;
+    private final RandomNaggingScheduler randomNaggingScheduler;
+    private final AsyncCardApprovalService asyncCardApprovalService;
+    private final BudgetMonitoringService budgetMonitoringService;
+    private final CardApprovalService cardApprovalService;
+    private final NotificationService notificationService;
+    private final UserMapper userMapper;
+
+    /**
+     * 모든 사용자 카드 승인내역 동기화 스케줄러 수동 실행
+     */
+    @PostMapping("/card-sync")
+    public ResponseEntity<Map<String, Object>> testCardSyncScheduler() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 카드 승인내역 동기화 스케줄러 수동 테스트 시작 ===");
+
+            // 스케줄러 수동 실행
+            cardApprovalScheduler.syncAllUsersCardApprovals();
+
+            response.put("status", "success");
+            response.put("message", "카드 승인내역 동기화 스케줄러 실행 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("카드 승인내역 동기화 스케줄러 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 특정 사용자 카드 승인내역 동기화 테스트
+     */
+    @PostMapping("/card-sync/user/{userId}")
+    public ResponseEntity<Map<String, Object>> testUserCardSync(@PathVariable Long userId) {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 사용자 {} 카드 승인내역 동기화 테스트 시작 ===", userId);
+
+            // 비동기 서비스로 특정 사용자 처리
+            asyncCardApprovalService.processUserCardApprovalsAsync(userId);
+
+            response.put("status", "success");
+            response.put("message", "사용자 " + userId + " 카드 동기화 실행 완료");
+            response.put("userId", userId);
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("사용자 {} 카드 동기화 테스트 실패", userId, e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 특정 사용자 예산 모니터링 테스트
+     */
+    @PostMapping("/budget-check/user/{userId}")
+    public ResponseEntity<Map<String, Object>> testUserBudgetCheck(@PathVariable Long userId) {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 사용자 {} 예산 모니터링 테스트 시작 ===", userId);
+
+            // 예산 모니터링 수동 실행
+            budgetMonitoringService.checkBudgetAndSendNotifications(userId);
+
+            // 예산 데이터 조회해서 응답에 포함
+            BudgetMonitoringDTO budgetData =
+                cardApprovalService.getBudgetMonitoringData(userId);
+
+            response.put("status", "success");
+            response.put("message", "사용자 " + userId + " 예산 모니터링 완료");
+            response.put("userId", userId);
+            response.put("hasBudget", budgetData.isHasBudget());
+            response.put("isOverBudget", budgetData.isOverBudget());
+            response.put("isWarningLevel", budgetData.isWarningLevel());
+            response.put("usageRate", budgetData.getUsageRate());
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("사용자 {} 예산 모니터링 테스트 실패", userId, e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 랜덤 잔소리 스케줄러 수동 실행
+     */
+    @PostMapping("/random-nagging")
+    public ResponseEntity<Map<String, Object>> testRandomNaggingScheduler() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 랜덤 잔소리 스케줄러 수동 테스트 시작 ===");
+
+            // 스케줄러 수동 실행 (07~ 다음날 01시까지 30분간격으로 날리는거임 실제 실행 X)
+//            randomNaggingScheduler.sendRandomNaggingNotifications();
+            // 스케줄러 수동 실행 (지금 시간부터 3분간 매 1분마다 발송 테스트용)
+            randomNaggingScheduler.sendRandomNaggingNotificationsForTest();
+
+            response.put("status", "success");
+            response.put("message", "랜덤 잔소리 스케줄러 실행 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("랜덤 잔소리 스케줄러 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 스케줄러 대상 사용자 목록 조회
+     */
+    @GetMapping("/users")
+    public ResponseEntity<Map<String, Object>> getSchedulerTargetUsers() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            // 카드 등록된 사용자
+            List<User> usersWithCards = userMapper.findUsersWithCards();
+            List<Long> cardUserIds = usersWithCards.stream()
+                    .map(User::getId)
+                    .collect(Collectors.toList());
+
+            // FCM 토큰 등록된 사용자
+            List<User> usersWithTokens = userMapper.findUsersWithFcmTokens();
+            List<Long> tokenUserIds = usersWithTokens.stream()
+                    .map(User::getId)
+                    .collect(Collectors.toList());
+
+            response.put("status", "success");
+            response.put("usersWithCards", cardUserIds);
+            response.put("usersWithFcmTokens", tokenUserIds);
+            response.put("cardUsersCount", cardUserIds.size());
+            response.put("tokenUsersCount", tokenUserIds.size());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("스케줄러 대상 사용자 조회 실패", e);
+            response.put("status", "error");
+            response.put("message", "조회 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 스케줄러 상태 확인
+     */
+    @GetMapping("/status")
+    public ResponseEntity<Map<String, Object>> getSchedulerStatus() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            response.put("status", "active");
+            response.put("message", "스케줄러가 정상 동작 중입니다");
+            response.put("schedulers", Map.of(
+                "cardApprovalScheduler", "08:00, 12:00, 18:00, 00:00 실행",
+                "randomNaggingScheduler", "매 30분마다 실행 (07:00-01:00)",
+                "healthCheckScheduler", "매시간 정각 실행"
+            ));
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            response.put("status", "error");
+            response.put("message", "상태 확인 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+}

--- a/src/main/java/com/savit/scheduler/job/CardApprovalScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/CardApprovalScheduler.java
@@ -1,0 +1,84 @@
+package com.savit.scheduler.job;
+
+import com.savit.card.service.AsyncCardApprovalService;
+import com.savit.user.mapper.UserMapper;
+import com.savit.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 내부 메서드 호출 방식 - 카드 승인내역 자동 동기화 스케줄러
+ * 09:00, 12:00, 18:00, 00:00에 실행되어 모든 사용자의 카드 승인내역을 자동으로 동기화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CardApprovalScheduler {
+
+    private final AsyncCardApprovalService asyncCardApprovalService;
+    private final UserMapper userMapper;
+
+    /**
+     * 내부 메서드 호출 방식 - 카드 승인내역 자동 동기화 (하루 4회)
+     * 08:00, 12:00, 18:00, 00:00에 실행
+     * cron = "초 분 시 일 월 요일"
+     */
+    @Scheduled(cron = "0 0 8,12,18,0 * * *")
+    public void syncAllUsersCardApprovals() {
+        log.info("===== 카드 승인내역 자동 동기화 스케줄러 시작 =====");
+
+        try {
+            // 1. 활성 사용자 목록 조회 (카드가 등록된 사용자만)
+            List<User> activeUsers = userMapper.findUsersWithCards();
+
+            if (activeUsers.isEmpty()) {
+                log.info("카드가 등록된 활성 사용자가 없습니다. 스케줄러를 종료합니다.");
+                return;
+            }
+
+            log.info("카드 승인내역 동기화 대상 사용자: {}명", activeUsers.size());
+
+            // 2. 각 사용자별로 비동기 처리 시작
+            List<Long> userIds = activeUsers.stream()
+                    .map(User::getId)
+                    .collect(Collectors.toList());
+
+            int processedCount = 0;
+            for (Long userId : userIds) {
+                try {
+                    // 내부 메서드 호출 방식 - 비동기로 사용자별 카드 승인내역 처리
+                    asyncCardApprovalService.processUserCardApprovalsAsync(userId);
+                    processedCount++;
+
+                    // 외부 API 호출 부하 분산을 위한 대기시간 (5000ms)
+                    Thread.sleep(5000);
+
+                } catch (Exception e) {
+                    log.error("사용자 {} 카드 승인내역 처리 시작 실패", userId, e);
+                }
+            }
+
+            // 3. 처리 현황 로깅
+            asyncCardApprovalService.logAsyncProcessingStatus(activeUsers.size(), processedCount);
+
+            log.info("===== 카드 승인내역 자동 동기화 스케줄러 완료 - 처리 시작: {}명 =====", processedCount);
+
+        } catch (Exception e) {
+            log.error("카드 승인내역 자동 동기화 스케줄러 실행 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 내부 메서드 호출 방식 - 스케줄러 상태 체크 (매시간 정각)
+     * 스케줄러가 정상 동작하는지 확인용 로그
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    public void schedulerHealthCheck() {
+        log.debug("카드 승인내역 스케줄러 상태 체크 - 정상 동작 중");
+    }
+}

--- a/src/main/java/com/savit/scheduler/job/RandomNaggingScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/RandomNaggingScheduler.java
@@ -1,0 +1,163 @@
+package com.savit.scheduler.job;
+
+import com.savit.notification.service.NotificationService;
+import com.savit.user.mapper.UserMapper;
+import com.savit.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * 내부 메서드 호출 방식 - 랜덤 잔소리 알림 스케줄러
+ * 오전 7시부터 다음날 오전 1시까지 랜덤한 시간에 잔소리 알림 발송
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RandomNaggingScheduler {
+
+    private final NotificationService notificationService;
+    private final UserMapper userMapper;
+    private final Random random = new Random();
+
+
+    /**
+     * 테스트용 - 랜덤 잔소리 알림 (1분 후 딱 한번만 실행)
+     * 서버 시작 1분 후에 딱 한번만 실행되는 테스트용 스케줄러
+     */
+    @Scheduled(initialDelay = 60000,  fixedDelay = Long.MAX_VALUE) // 1분 후 실행, 한번만 (29만년후 다시실행)
+    public void sendRandomNaggingNotificationsForTest() {
+        log.info("===== 테스트용 랜덤 잔소리 알림 스케줄러 시작 (딱 한번만 실행) =====");
+
+        try {
+            // 1. FCM 토큰이 등록된 활성 사용자 목록 조회
+            List<User> activeUsers = userMapper.findUsersWithFcmTokens();
+
+            if (activeUsers.isEmpty()) {
+                log.info("FCM 토큰이 등록된 사용자가 없습니다.");
+                return;
+            }
+
+            log.info("테스트용 랜덤 잔소리 알림 대상 사용자: {}명", activeUsers.size());
+
+            // 2. 각 사용자별로 100% 확률로 잔소리 알림 발송 (테스트용)
+            int sentCount = 0;
+            for (User user : activeUsers) {
+                try {
+                    // 100% 확률로 알림 발송 (테스트용)
+                    notificationService.sendRandomNaggingNotification(user.getId());
+                    sentCount++;
+
+                    // 알림 발송 간격 조절 (300ms 대기)
+                    Thread.sleep(300);
+
+                } catch (Exception e) {
+                    log.error("사용자 {} 테스트용 랜덤 잔소리 알림 발송 실패", user.getId(), e);
+                }
+            }
+
+            log.info("===== 테스트용 랜덤 잔소리 알림 스케줄러 완료 - 대상: {}명, 발송: {}명 (딱 한번 실행 완료) =====",
+                    activeUsers.size(), sentCount);
+
+        } catch (Exception e) {
+            log.error("테스트용 랜덤 잔소리 알림 스케줄러 실행 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 운영용 실제 메서드
+     * 내부 메서드 호출 방식 - 랜덤 잔소리 알림 (4시간마다)
+     * 오전 8시부터 다음날 00시까지 4시간 간격으로 총 4번 실행
+     * 08:00, 12:00, 16:00, 20:00에 실행
+     */
+    @Scheduled(cron = "0 0 8,12,16,20 * * *") // 08:00, 12:00, 16:00, 20:00에 실행
+    public void sendRandomNaggingNotifications() {
+        log.info("===== 랜덤 잔소리 알림 스케줄러 시작 (4시간마다) =====");
+
+        try {
+            // 1. FCM 토큰이 등록된 활성 사용자 목록 조회
+            List<User> activeUsers = userMapper.findUsersWithFcmTokens();
+
+            if (activeUsers.isEmpty()) {
+                log.info("FCM 토큰이 등록된 사용자가 없습니다.");
+                return;
+            }
+
+            log.info("랜덤 잔소리 알림 대상 사용자: {}명", activeUsers.size());
+
+            // 2. 각 사용자별로 50% 확률로 잔소리 알림 발송
+            int sentCount = 0;
+            for (User user : activeUsers) {
+                try {
+                    // 50% 확률로 알림 발송
+                    if (random.nextBoolean()) {
+                        // 내부 메서드 호출 방식 - 랜덤 잔소리 알림 발송
+                        notificationService.sendRandomNaggingNotification(user.getId());
+                        sentCount++;
+
+                        // 알림 발송 간격 조절 (500ms 대기)
+                        Thread.sleep(500);
+                    }
+                } catch (Exception e) {
+                    log.error("사용자 {} 랜덤 잔소리 알림 발송 실패", user.getId(), e);
+                }
+            }
+
+            log.info("===== 랜덤 잔소리 알림 스케줄러 완료 - 대상: {}명, 발송: {}명 =====",
+                    activeUsers.size(), sentCount);
+
+        } catch (Exception e) {
+            log.error("랜덤 잔소리 알림 스케줄러 실행 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 내부 메서드 호출 방식 - 랜덤 하루 마무리 알림 (매일 오후 9시)
+     * 하루를 마무리하는 시간에 푸시 발송
+     */
+    @Scheduled(cron = "0 0 21 * * *") // 매일 오후 9시
+    public void sendDailyWrapUpNagging() {
+        log.info("===== 하루 마무리 알림 시작 =====");
+
+        try {
+            List<User> activeUsers = userMapper.findUsersWithFcmTokens();
+
+            if (activeUsers.isEmpty()) {
+                log.info("FCM 토큰이 등록된 사용자가 없습니다.");
+                return;
+            }
+
+            String[] wrapUpMessages = {
+                "오늘 하루 신용카드는 덜 썼죠? 📝",
+                "내일을 위해 오늘의 지출을 돌아봐요! 💭",
+                "오늘 하루도 고생했어요! 내일도 신용카드 덜쓰기! ✅",
+                "오늘 얼마나 썼는지 체크해볼까요? 💰"
+            };
+
+            int sentCount = 0;
+            for (User user : activeUsers) {
+                try {
+                    // 30% 확률로 하루 마무리 메시지 발송
+                    if (random.nextInt(100) < 30) {
+                        String message = wrapUpMessages[random.nextInt(wrapUpMessages.length)];
+                        notificationService.sendNotificationToUser(user.getId(), "💬 Savit 한마디", message);
+                        sentCount++;
+
+                        Thread.sleep(300);
+                    }
+                } catch (Exception e) {
+                    log.error("사용자 {} 하루 마무리 알림 발송 실패", user.getId(), e);
+                }
+            }
+
+            log.info("===== 하루 마무리 잔소리 알림 완료 - 대상: {}명, 발송: {}명 =====",
+                    activeUsers.size(), sentCount);
+
+        } catch (Exception e) {
+            log.error("하루 마무리 잔소리 알림 실행 중 오류 발생", e);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 작업 내용
  - 카드 승인내역 자동 동기화 및 사용자 알림을 위한 스케줄러 시스템 구현 (Cron 표현식 기반 정확한 스케줄 실행)
  - 비동기 처리로 사용자별 병렬 카드 동기화
  - 외부 API 호출 부하 분산을 위한 5초 대기 간격
  - 스케줄러 실행 현황 상세 로깅 및 상태 추적

## 🔧 주요 변경 사항
  - 카드 승인내역 자동 동기화 스케줄러 (하루 4회 -> 08:00, 12:00, 18:00, 00:00)
  - 랜덤 잔소리 알림 스케줄러 (4시간마다 50% 확률)
  - 랜덤 하루 마무리 알림 스케줄러 (매일 21:00, 30% 확률)
  - 스케줄러 수동 테스트 및 상태 모니터링 API

## 📌 관련 이슈
- closes #76 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 스케줄러 정시 실행 확인
- [ ] 비동기 카드 동기화 확인 (1장만 확인, 여러장 확인 못함(codef로 카드 여러개 가져오신분 있으시면 동기화 확인 부탁드립니다))
- [x] FCM 알림 발송 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함