### PR TITLE
[feat] 카드 등록 시 중복 저장 방지 로직 추가 (#98)

### DIFF
--- a/src/main/java/com/savit/card/mapper/CardMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardMapper.java
@@ -12,4 +12,5 @@ public interface CardMapper {
     Card selectCardByIdAndUserId(@Param("cardId") Long cardId, @Param("userId") Long userId);
     int selectMonthlyUsageAmount(@Param("cardId") Long cardId);
     List<Card> selectCardsByUserId(Long userId);
+    boolean existsCardByResCardNoAndUserId(@Param("resCardNo") String resCardNo, @Param("userId") Long userId);
 }

--- a/src/main/java/com/savit/card/service/CardService.java
+++ b/src/main/java/com/savit/card/service/CardService.java
@@ -111,7 +111,12 @@ public class CardService {
                           String encryptedCardNo,
                           String cardPassword) {
 
-        List<Card> cards = cardDataList.stream().map(data -> Card.builder()
+        List<Card> cards = cardDataList.stream()
+                .filter(data -> {
+                    String resCardNo = (String) data.get("resCardNo");
+                    return !cardMapper.existsCardByResCardNoAndUserId(resCardNo, userId);
+                })
+                .map(data -> Card.builder()
                         .connectedId(connectedId)
                         .organization(organization)
                         .cardName((String) data.get("resCardName"))
@@ -131,7 +136,9 @@ public class CardService {
                         .build())
                 .toList();
 
-        cardMapper.insertCards(cards);
+        if (!cards.isEmpty()) {
+            cardMapper.insertCards(cards);
+        }
     }
 
     public CardDetailResponseDTO getCardDetailWithUsage(Long cardId, Long userId) {

--- a/src/main/resources/mapper/card/CardMapper.xml
+++ b/src/main/resources/mapper/card/CardMapper.xml
@@ -38,6 +38,14 @@
         </foreach>
     </insert>
 
+    <select id="existsCardByResCardNoAndUserId" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM Card
+            WHERE res_card_no = #{resCardNo}
+              AND user_id = #{userId}
+        )
+    </select>
+
     <select id="selectCardByIdAndUserId" resultType="com.savit.card.domain.Card">
         SELECT * FROM Card
         WHERE id = #{cardId}
@@ -45,7 +53,7 @@
     </select>
 
     <select id="selectCardsByUserId" resultType="com.savit.card.domain.Card">
-        SELECT * FROM card
+        SELECT * FROM Card
         WHERE user_id = #{userId}
     </select>
 


### PR DESCRIPTION
## ✅ 작업 내용
- 카드 등록 시 중복된 카드(resCardNo + userId 조합)는 저장하지 않도록 예외 처리 추가
- `CardService#saveCards()` 내부 로직 수정
- `CardMapper.existsCardByResCardNoAndUserId` 메서드 및 XML 쿼리 추가

## 🔧 주요 변경 사항
- CardService.java
- CardMapper.java
- CardMapper.xml

## 📌 관련 이슈
- closes #98 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함