### PR TITLE
[fix] 누락된 </select> 태그 추가로 ChallengeMapper XML 오류 해결 (#100)

### DIFF
--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -41,6 +41,7 @@
         FROM ChallengeParticipation
         WHERE challenge_id = #{challengeId}
           AND status = 'PARTICIPATING'
+    </select>
 
     <!--참여 가능한 1주 챌린지 목록 조회(1번 여부 상관 없이 조회됨)-->
     <select id="findWeeklyChallenges" resultType="com.savit.challenge.dto.ChallengeListDTO">


### PR DESCRIPTION
## ✅ 작업 내용
- ChallengeMapper.xml에서 누락된 `</select>` 태그 추가

## 📌 관련 이슈
- closes #100

## 🔧 영향 범위
- 빌드 실패 원인 제거 → 이후 기능 개발 분기 가능