### PR TITLE
[feat] 아임포트 결제 웹훅 처리 및 챌린지 참여 등록(#102)

### DIFF
--- a/src/main/java/com/savit/challenge/controller/PaymentVerificationController.java
+++ b/src/main/java/com/savit/challenge/controller/PaymentVerificationController.java
@@ -1,0 +1,33 @@
+package com.savit.challenge.controller;
+
+import com.savit.challenge.service.IamportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentVerificationController {
+
+    private final IamportService iamportService;
+
+    @PostMapping("/verify")
+    public ResponseEntity<String> verifyDirectly(@RequestBody Map<String, String> body) {
+        String impUid = body.get("impUid");
+
+        log.info("========= [Verify] 받은 imp_uid: {}", impUid);
+
+        try {
+            iamportService.processWebhook(impUid);
+            return ResponseEntity.ok("verified");
+        } catch (Exception e) {
+            log.error("======== [Verify] 처리 실패", e);
+            return ResponseEntity.status(500).body("fail");
+        }
+    }
+}

--- a/src/main/java/com/savit/challenge/controller/PaymentWebhookController.java
+++ b/src/main/java/com/savit/challenge/controller/PaymentWebhookController.java
@@ -1,0 +1,35 @@
+package com.savit.challenge.controller;
+
+import com.savit.challenge.service.IamportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentWebhookController {
+
+    private final IamportService iamportService;
+
+    @PostMapping("/webhook")
+    public ResponseEntity<String> receiveWebhook(@RequestBody Map<String, Object> payload) {
+        String impUid = (String) payload.get("imp_uid");
+
+        log.info("========= [Webhook] 받은 imp_uid: {}", impUid);
+        try {
+            iamportService.processWebhook(impUid);
+            return ResponseEntity.ok("success");
+        } catch (Exception e) {
+            log.error("======== [Webhook] 처리 실패", e);
+            return ResponseEntity.status(500).body("fail");
+        }
+    }
+}

--- a/src/main/java/com/savit/challenge/dto/IamportPaymentResponseDTO.java
+++ b/src/main/java/com/savit/challenge/dto/IamportPaymentResponseDTO.java
@@ -1,0 +1,16 @@
+package com.savit.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class IamportPaymentResponseDTO {
+    private String impUid;
+    private String merchantUid;
+    private long amount;
+    private String status;
+    private long paidAt;
+    private Long challengeId;
+    private Long userId;
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
@@ -1,0 +1,16 @@
+package com.savit.challenge.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.math.BigDecimal;
+
+@Mapper
+public interface ChallengeParticipationMapper {
+    boolean existsParticipation(@Param("challengeId") Long challengeId,
+                                @Param("userId") Long userId);
+
+    void insertParticipation(@Param("challengeId") Long challengeId,
+                             @Param("userId") Long userId,
+                             @Param("myFee") BigDecimal myFee);
+}

--- a/src/main/java/com/savit/challenge/mapper/PaymentMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/PaymentMapper.java
@@ -1,0 +1,19 @@
+package com.savit.challenge.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Date;
+
+@Mapper
+public interface PaymentMapper {
+    void insertPayment(
+            @Param("merchantUid") String merchantUid,
+            @Param("impUid") String impUid,
+            @Param("paidAt") Date paidAt,
+            @Param("amount") long amount,
+            @Param("status") String status,
+            @Param("challengeId") long challengeId,
+            @Param("userId") long userId
+    );
+}

--- a/src/main/java/com/savit/challenge/service/IamportService.java
+++ b/src/main/java/com/savit/challenge/service/IamportService.java
@@ -1,0 +1,5 @@
+package com.savit.challenge.service;
+
+public interface IamportService {
+    void processWebhook(String impUid);
+}

--- a/src/main/java/com/savit/challenge/service/IamportServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/IamportServiceImpl.java
@@ -1,0 +1,134 @@
+package com.savit.challenge.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.savit.challenge.dto.IamportPaymentResponseDTO;
+import com.savit.challenge.mapper.ChallengeParticipationMapper;
+import com.savit.challenge.mapper.PaymentMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class IamportServiceImpl implements IamportService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final PaymentMapper paymentMapper;
+    private final ChallengeParticipationMapper participationMapper;
+
+    @Value("${iamport.api-key}")
+    private String apiKey;
+
+    @Value("${iamport.api-secret}")
+    private String apiSecret;
+
+    @Override
+    @Transactional
+    public void processWebhook(String impUid) {
+        String accessToken = fetchAccessToken();
+
+        IamportPaymentResponseDTO payment = fetchPaymentInfo(impUid, accessToken);
+        if (!"paid".equals(payment.getStatus())) {
+            throw new IllegalStateException("결제 상태가 paid가 아님");
+        }
+
+        // 1. 결제 정보 저장
+        paymentMapper.insertPayment(
+                payment.getMerchantUid(),
+                payment.getImpUid(),
+                new Date(payment.getPaidAt() * 1000L),
+                payment.getAmount(),
+                "SUCCESS",
+                payment.getChallengeId(),
+                payment.getUserId()
+        );
+
+        // 2. 챌린지 참여 여부 확인
+        boolean alreadyJoined = participationMapper.existsParticipation(
+                payment.getChallengeId(),
+                payment.getUserId()
+        );
+
+        // 3. 없을 경우 참여 확정 insert
+        if (!alreadyJoined) {
+            participationMapper.insertParticipation(
+                    payment.getChallengeId(),
+                    payment.getUserId(),
+                    BigDecimal.valueOf(payment.getAmount())
+            );
+            log.info("챌린지 참여 등록 완료: challengeId={}, userId={}",
+                    payment.getChallengeId(), payment.getUserId());
+        } else {
+            log.warn("이미 참여한 챌린지입니다: challengeId={}, userId={}",
+                    payment.getChallengeId(), payment.getUserId());
+        }
+
+        log.info("결제 완료 처리: merchant_uid={}, userId={}, amount={}",
+                payment.getMerchantUid(), payment.getUserId(), payment.getAmount());
+    }
+
+    private String fetchAccessToken() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        Map<String, String> payload = Map.of(
+                "imp_key", apiKey,
+                "imp_secret", apiSecret
+        );
+
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(payload, headers);
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "https://api.iamport.kr/users/getToken", request, Map.class);
+
+        return (String) ((Map) response.getBody().get("response")).get("access_token");
+    }
+
+    private IamportPaymentResponseDTO fetchPaymentInfo(String impUid, String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://api.iamport.kr/payments/" + impUid,
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        Map<String, Object> data = (Map<String, Object>) response.getBody().get("response");
+        Map<String, Object> customData = parseCustomData(data.get("custom_data"));
+
+        return new IamportPaymentResponseDTO(
+                (String) data.get("imp_uid"),
+                (String) data.get("merchant_uid"),
+                ((Number) data.get("amount")).intValue(),
+                (String) data.get("status"),
+                ((Number) data.get("paid_at")).longValue(),
+                ((Number) customData.get("challengeId")).longValue(),
+                ((Number) customData.get("userId")).longValue()
+        );
+    }
+
+    private Map<String, Object> parseCustomData(Object customDataRaw) {
+        if (customDataRaw instanceof Map) {
+            return (Map<String, Object>) customDataRaw;
+        } else if (customDataRaw instanceof String) {
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                return objectMapper.readValue((String) customDataRaw, Map.class);
+            } catch (Exception e) {
+                throw new RuntimeException("custom_data 문자열 파싱 실패", e);
+            }
+        }
+        throw new RuntimeException("custom_data가 Map 또는 JSON 문자열이 아님");
+    }
+
+}

--- a/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
@@ -1,0 +1,22 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.savit.challenge.mapper.ChallengeParticipationMapper">
+
+    <!-- 참여 여부 확인 -->
+    <select id="existsParticipation" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM ChallengeParticipation
+            WHERE challenge_id = #{challengeId} AND user_id = #{userId}
+        )
+    </select>
+
+    <!-- 챌린지 참여 삽입 -->
+    <insert id="insertParticipation">
+        INSERT INTO ChallengeParticipation (
+            challenge_id, user_id, status, my_fee, created_at
+        ) VALUES (
+                     #{challengeId}, #{userId}, 'PARTICIPATING', #{myFee}, NOW()
+                 )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/challenge/PaymentMapper.xml
+++ b/src/main/resources/mapper/challenge/PaymentMapper.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.savit.challenge.mapper.PaymentMapper">
+
+    <insert id="insertPayment">
+        INSERT INTO Payment (
+            merchant_uid, imp_uid, paid_at, amount, status, challenge_id, user_id
+        ) VALUES (
+                     #{merchantUid}, #{impUid}, #{paidAt}, #{amount}, #{status}, #{challengeId}, #{userId}
+                 )
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## ✅ 작업 내용

- 아임포트 결제 웹훅 수신 API(`/api/payments/webhook`) 구현
- 아임포트 서버로부터 imp_uid를 전달받아 결제 정보를 조회하고 DB 저장
- 결제 성공 시 ChallengeParticipation 테이블에 참여 정보 insert
- custom_data로부터 challengeId, userId 추출
- 이미 참여된 챌린지일 경우 중복 삽입 방지
- (보조) 수동 결제 검증용 `/api/payments/verify` API도 추가하였으며, 웹훅 호출 실패 상황 등을 대비한 대안용

## 🔧 주요 변경 사항

- `PaymentWebhookController` 클래스 추가
- `PaymentVerificationController` 클래스 추가 (보조용)
- `IamportServiceImpl` 결제 정보 처리 로직 구현
- `IamportPaymentResponseDTO` 생성
- `ChallengeParticipationMapper.xml`, `PaymentMapper.xml`에 insert 및 exists 쿼리 추가

## 📌 관련 이슈

- closes #102 

## 🔄 추후 개선 사항 (예정)

- 트랜잭션 내 비관적 락(Pessimistic Lock) 또는 idempotency 처리를 통한 중복 삽입 완전 방지
- `VO` 기반 처리로 응답 객체의 일관성 확보
- 참여 상태 확정 로직 분리 및 테스트 코드 작성

## 🚨 체크리스트

- [x] 빌드 및 실행 오류 없음
- [x] 아임포트 웹훅 호출 시 DB 저장 정상 작동
- [x] 결제 완료 시 챌린지 참여 등록 확인
- [x] 중복 참여 방지 정상 작동
- [x] 리팩토링 계획 포함