### PR TITLE
[fix] 잔소리 알림 정확히 1회만 날라가게끔 수정 (#104)

### DIFF
--- a/src/main/java/com/savit/scheduler/job/RandomNaggingScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/RandomNaggingScheduler.java
@@ -25,10 +25,10 @@ public class RandomNaggingScheduler {
 
 
     /**
-     * 테스트용 - 랜덤 잔소리 알림 (1분 후 딱 한번만 실행)
+     * 테스트용 - 랜덤 잔소리 알림 (테스트 완료로 비활성화)
      * 서버 시작 1분 후에 딱 한번만 실행되는 테스트용 스케줄러
      */
-    @Scheduled(initialDelay = 60000,  fixedDelay = Long.MAX_VALUE) // 1분 후 실행, 한번만 (29만년후 다시실행)
+    // @Scheduled(initialDelay = 60000,  fixedDelay = Long.MAX_VALUE) // 테스트 완료로 비활성화
     public void sendRandomNaggingNotificationsForTest() {
         log.info("===== 테스트용 랜덤 잔소리 알림 스케줄러 시작 (딱 한번만 실행) =====");
 


### PR DESCRIPTION
## ✅ 작업 내용
- 잔소리 알림 정확히 1회만 날라가게 수정 완료

## 🔧 주요 변경 사항
- `@Scheduled` 어노테이션 부분 주석처리

## 📌 관련 이슈
- closes #104

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함