### PR TITLE
[fix] codef 토큰 중복 저장 오류 해결 (insert → insert or update 전환) (#109)

### DIFF
--- a/src/main/java/com/savit/card/mapper/CodefTokenMapper.java
+++ b/src/main/java/com/savit/card/mapper/CodefTokenMapper.java
@@ -6,5 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface CodefTokenMapper {
     CodefToken findValidToken();
+    boolean exists();
     int insertToken(CodefToken token);
+    int updateToken(CodefToken token);
 }

--- a/src/main/java/com/savit/card/repository/CodefTokenRepository.java
+++ b/src/main/java/com/savit/card/repository/CodefTokenRepository.java
@@ -16,6 +16,10 @@ public class CodefTokenRepository {
         return Optional.ofNullable(mapper.findValidToken());
     }
     public void save(CodefToken token) {
-        mapper.insertToken(token);
+        if (mapper.exists()) {
+            mapper.updateToken(token);
+        } else {
+            mapper.insertToken(token);
+        }
     }
 }

--- a/src/main/resources/mapper/card/CodefTokenMapper.xml
+++ b/src/main/resources/mapper/card/CodefTokenMapper.xml
@@ -20,6 +20,10 @@
             LIMIT  1
     </select>
 
+    <select id="exists" resultType="boolean">
+        SELECT EXISTS (SELECT 1 FROM CodefAccessToken)
+    </select>
+
     <insert id="insertToken"
             parameterType="com.savit.card.domain.CodefToken"
             useGeneratedKeys="true"
@@ -29,5 +33,13 @@
         VALUES
             (#{accessToken}, #{expiresAt}, #{createdAt}, #{updatedAt})
     </insert>
+
+    <update id="updateToken"
+            parameterType="com.savit.card.domain.CodefToken">
+        UPDATE CodefAccessToken
+        SET access_token = #{accessToken},
+            expires_at   = #{expiresAt},
+            updated_at   = #{updatedAt}
+    </update>
 
 </mapper>


### PR DESCRIPTION
### 🔧 주요 변경 사항

- 기존 `insertToken()` 방식에서 `insert or update` 방식으로 개선
- 테이블에 row가 존재하면 `updateToken()` 수행하도록 로직 분기
- `CodefAccessToken`은 항상 하나만 존재하는 구조 유지

---

### ✅ 작업 파일

- `CodefTokenRepository.java`
  - `save()` 내부 로직 수정
- `CodefTokenMapper.java`
  - `exists()`, `updateToken()` 메서드 추가
- `CodefTokenMapper.xml`
  - `SELECT EXISTS`, `UPDATE` 쿼리 추가

---

### 📎 관련 이슈

closes #109 

---

### 🧪 테스트

- `expires_at` 값을 수동 만료 후 등록 시도
- 중복 저장 없이 UPDATE 정상 동작 확인
- 재발급된 accessToken 저장 및 만료일 최신화 정상 확인
