### PR TITLE
[feat] 일일 최고 지출 푸시 알림 구현 (#111)

### DIFF
--- a/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
@@ -1,6 +1,7 @@
 package com.savit.card.mapper;
 
 import com.savit.card.domain.CardTransactionVO;
+import org.apache.ibatis.annotations.MapKey;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -31,4 +32,9 @@ public interface CardTransactionMapper {
     BigDecimal sumAmountByParams (Map<String, Object> params);
     // 2) 횟수 기준: type = COUNT
     Long countByParams(Map<String, Object> params);
+
+    // 전날 최고 지출 항목 조회 (사용자별, 카테고리명 포함)
+    @MapKey("id") // 단일 결과여서 없어도 되는데 빨간 오류줄 없애려고 추가
+    Map<String, Object> findTopSpendingByUserAndDate(@Param("userId") Long userId,
+                                                     @Param("targetDate") String targetDate);
 }

--- a/src/main/java/com/savit/notification/domain/DailyTopSpending.java
+++ b/src/main/java/com/savit/notification/domain/DailyTopSpending.java
@@ -1,0 +1,28 @@
+package com.savit.notification.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 일일 최고 지출 데이터 저장용 도메인
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyTopSpending {
+    private Long id;
+    private Long userId;
+    private String targetDate; // YYYYMMDD 형식
+    private String categoryName;
+    private BigDecimal amount;
+    private String storeName;
+    private LocalDateTime createdAt;
+    private boolean notificationSent; // 알림 발송 여부
+}

--- a/src/main/java/com/savit/notification/mapper/DailyTopSpendingMapper.java
+++ b/src/main/java/com/savit/notification/mapper/DailyTopSpendingMapper.java
@@ -1,0 +1,24 @@
+package com.savit.notification.mapper;
+
+import com.savit.notification.domain.DailyTopSpending;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface DailyTopSpendingMapper {
+    
+    // 일일 최고 지출 데이터 저장
+    void insertDailyTopSpending(DailyTopSpending dailyTopSpending);
+    
+    // 알림 미발송 데이터 조회 (09시 알림용)
+    List<DailyTopSpending> findPendingNotifications();
+    
+    // 알림 발송 완료 처리
+    void markNotificationSent(@Param("id") Long id);
+    
+    // 중복 체크 (같은 사용자, 같은 날짜)
+    boolean existsByUserAndDate(@Param("userId") Long userId, 
+                               @Param("targetDate") String targetDate);
+}

--- a/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
+++ b/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
@@ -36,6 +36,7 @@ public class SchedulerTestController {
     private final CardApprovalService cardApprovalService;
     private final NotificationService notificationService;
     private final UserMapper userMapper;
+    private final com.savit.scheduler.job.DailyTopSpendingScheduler dailyTopSpendingScheduler;
 
     /**
      * 모든 사용자 카드 승인내역 동기화 스케줄러 수동 실행
@@ -215,6 +216,58 @@ public class SchedulerTestController {
         } catch (Exception e) {
             response.put("status", "error");
             response.put("message", "상태 확인 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 일일 최고 지출 데이터 수집 테스트
+     */
+    @PostMapping("/daily-top-spending/collect")
+    public ResponseEntity<Map<String, Object>> testCollectDailyTopSpending() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 일일 최고 지출 데이터 수집 수동 테스트 시작 ===");
+
+            dailyTopSpendingScheduler.collectDailyTopSpending();
+
+            response.put("status", "success");
+            response.put("message", "일일 최고 지출 데이터 수집 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("일일 최고 지출 데이터 수집 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 일일 최고 지출 알림 발송 테스트
+     */
+    @PostMapping("/daily-top-spending/notify")
+    public ResponseEntity<Map<String, Object>> testSendDailyTopSpendingNotifications() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 일일 최고 지출 알림 발송 수동 테스트 시작 ===");
+
+            dailyTopSpendingScheduler.sendDailyTopSpendingNotifications();
+
+            response.put("status", "success");
+            response.put("message", "일일 최고 지출 알림 발송 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("일일 최고 지출 알림 발송 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
             return ResponseEntity.internalServerError().body(response);
         }
     }

--- a/src/main/java/com/savit/scheduler/job/DailyTopSpendingScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/DailyTopSpendingScheduler.java
@@ -1,0 +1,142 @@
+package com.savit.scheduler.job;
+
+import com.savit.card.mapper.CardTransactionMapper;
+import com.savit.notification.domain.DailyTopSpending;
+import com.savit.notification.mapper.DailyTopSpendingMapper;
+import com.savit.notification.service.NotificationService;
+import com.savit.user.domain.User;
+import com.savit.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 일일 최고 지출 알림 스케줄러
+ * - 00:15: 전날 최고 지출 데이터 수집
+ * - 09:00: 알림 발송
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyTopSpendingScheduler {
+
+    private final CardTransactionMapper cardTransactionMapper;
+    private final DailyTopSpendingMapper dailyTopSpendingMapper;
+    private final NotificationService notificationService;
+    private final UserMapper userMapper;
+
+    /**
+     * 실제 운영용 코드임
+     * 전날 최고 지출 데이터 수집 (매일 00:15)
+     */
+    @Scheduled(cron = "0 15 0 * * *")
+    public void collectDailyTopSpending() {
+        log.info("===== 일일 최고 지출 데이터 수집 시작 =====");
+
+        try {
+            // 전날 날짜 (YYYYMMDD 형식)
+            String yesterday = LocalDate.now().minusDays(1)
+                    .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            log.info("수집 대상 날짜: {}", yesterday);
+
+            // FCM 토큰이 있는 활성 사용자 목록 조회
+            List<User> activeUsers = userMapper.findUsersWithFcmTokens();
+            log.info("대상 사용자 수: {}명", activeUsers.size());
+
+            int savedCount = 0;
+            for (User user : activeUsers) {
+                try {
+                    // 중복 체크
+                    if (dailyTopSpendingMapper.existsByUserAndDate(user.getId(), yesterday)) {
+                        log.debug("사용자 {}의 {} 데이터 이미 존재", user.getId(), yesterday);
+                        continue;
+                    }
+
+                    // 전날 최고 지출 항목 조회
+                    Map<String, Object> topSpending = cardTransactionMapper
+                            .findTopSpendingByUserAndDate(user.getId(), yesterday);
+
+                    if (topSpending != null && !topSpending.isEmpty()) {
+                        // DailyTopSpending 객체 생성 및 저장
+                        DailyTopSpending dailyData = DailyTopSpending.builder()
+                                .userId(user.getId())
+                                .targetDate(yesterday)
+                                .categoryName((String) topSpending.get("categoryName"))
+                                .amount(new BigDecimal((String) topSpending.get("res_used_amount")))
+                                .storeName((String) topSpending.get("res_member_store_name"))
+                                .build();
+
+                        dailyTopSpendingMapper.insertDailyTopSpending(dailyData);
+                        savedCount++;
+                        log.debug("사용자 {} 최고 지출 저장: {} - {}원", 
+                                user.getId(), dailyData.getCategoryName(), dailyData.getAmount());
+                    }
+
+                } catch (Exception e) {
+                    log.error("사용자 {} 데이터 수집 실패", user.getId(), e);
+                }
+            }
+
+            log.info("===== 일일 최고 지출 데이터 수집 완료: {}건 저장 =====", savedCount);
+
+        } catch (Exception e) {
+            log.error("일일 최고 지출 데이터 수집 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 실제 운영용 코드임
+     * 일일 최고 지출 알림 발송 (매일 09:00)
+     */
+    @Scheduled(cron = "0 0 9 * * *")
+    public void sendDailyTopSpendingNotifications() {
+        log.info("===== 일일 최고 지출 알림 발송 시작 =====");
+
+        try {
+            // 알림 미발송 데이터 조회
+            List<DailyTopSpending> pendingNotifications = dailyTopSpendingMapper.findPendingNotifications();
+            log.info("발송 대상: {}건", pendingNotifications.size());
+
+            int sentCount = 0;
+            for (DailyTopSpending data : pendingNotifications) {
+                try {
+                    // 알림 메시지 생성
+                    String message = String.format("너 어제 %s에 %s원이나 썼어! 이게 맞아? 💸", 
+                            data.getCategoryName(), 
+                            String.format("%,d", data.getAmount().intValue()));
+
+                    // FCM 알림 발송
+                    notificationService.sendNotificationToUser(
+                            data.getUserId(), 
+                            "💰 어제의 지출 TOP 1",
+                            message
+                    );
+
+                    // 발송 완료 처리
+                    dailyTopSpendingMapper.markNotificationSent(data.getId());
+                    sentCount++;
+
+                    log.info("사용자 {} 알림 발송 완료: {}", data.getUserId(), message);
+
+                    // 발송 간격 조절
+                    Thread.sleep(500);
+
+                } catch (Exception e) {
+                    log.error("사용자 {} 알림 발송 실패", data.getUserId(), e);
+                }
+            }
+
+            log.info("===== 일일 최고 지출 알림 발송 완료: {}건 발송 =====", sentCount);
+
+        } catch (Exception e) {
+            log.error("일일 최고 지출 알림 발송 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/resources/mapper/card/CardTransactionMapper.xml
+++ b/src/main/resources/mapper/card/CardTransactionMapper.xml
@@ -76,4 +76,18 @@
         AND (res_cancel_yn IS NULL OR res_cancel_yn != 'Y')
     </select>
 
+    <!-- 특정 날짜의 사용자별 최고 지출 항목 조회 (카테고리명 포함) -->
+    <select id="findTopSpendingByUserAndDate" resultType="map">
+        SELECT t.*, cat.name as categoryName
+        FROM CardTransaction t
+        JOIN Card c ON t.card_id = c.id
+        JOIN Category cat ON t.category_id = cat.id
+        WHERE c.user_id = #{userId}
+          AND t.res_used_date = #{targetDate}
+          AND (t.res_cancel_yn IS NULL OR t.res_cancel_yn != '1')
+          AND t.category_id IS NOT NULL
+        ORDER BY CAST(t.res_used_amount AS DECIMAL(12,2)) DESC
+        LIMIT 1
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/notification/DailyTopSpendingMapper.xml
+++ b/src/main/resources/mapper/notification/DailyTopSpendingMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.savit.notification.mapper.DailyTopSpendingMapper">
+
+    <!-- 일일 최고 지출 데이터 저장 -->
+    <insert id="insertDailyTopSpending">
+        INSERT INTO DailyTopSpending (user_id, target_date, category_name, amount, store_name, created_at, notification_sent)
+        VALUES (#{userId}, #{targetDate}, #{categoryName}, #{amount}, #{storeName}, NOW(), false)
+    </insert>
+
+    <!-- 알림 미발송 데이터 조회 -->
+    <select id="findPendingNotifications" resultType="com.savit.notification.domain.DailyTopSpending">
+        SELECT * FROM DailyTopSpending 
+        WHERE notification_sent = false
+        ORDER BY created_at
+    </select>
+
+    <!-- 알림 발송 완료 처리 -->
+    <update id="markNotificationSent">
+        UPDATE DailyTopSpending 
+        SET notification_sent = true 
+        WHERE id = #{id}
+    </update>
+
+    <!-- 중복 체크 -->
+    <select id="existsByUserAndDate" resultType="boolean">
+        SELECT COUNT(*) > 0 
+        FROM DailyTopSpending 
+        WHERE user_id = #{userId} 
+          AND target_date = #{targetDate}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 사용자의 전날 최고 지출을 추적하여 다음날 아침 맞춤형 푸시 알림을
  발송하는 시스템을 구현

## 🔧 주요 변경 사항
- 일일 최고 지출 데이터 저장용 도메인 객체 생성
- 일일 최고 지출 알림용 Mapper 인터페이스 및 SQL 쿼리 생성
- 일일 최고 지출 알림 스케줄러 생성
- 전날 최고 지출 항목 조회 메서드 추가
- 최고 지출 항목 조회 쿼리 추가 (Category 테이블 JOIN)
- 수동 테스트용 API 엔드포인트 추가 (SchedulerTestController.java)

## 🗄️ 새로운 테이블 생성 필요
- 노션 ERD -> DailyTopSpending 테이블 CREATE 문 

## 📌 관련 이슈
- closes #111 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 전날 최고 지출 데이터 수집 및 알림 발송 테스트
- [x] 중복 데이터 생성 방지 로직 검증
- [x] 카테고리명 조회 정확성 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함