### PR TITLE
[feat] 챌린지 개별 통계 기반 일일 낙오 요약 알림 시스템 구현 (#115)

### DIFF
--- a/src/main/java/com/savit/challenge/dto/ChallengeDropoutSummaryDTO.java
+++ b/src/main/java/com/savit/challenge/dto/ChallengeDropoutSummaryDTO.java
@@ -1,0 +1,22 @@
+package com.savit.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챌린지별 일일 낙오 요약 통계 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeDropoutSummaryDTO {
+    private Long challengeId;           // 챌린지 ID
+    private String challengeTitle;      // 챌린지 제목
+    private Long totalParticipants;     // 전체 참여자 수
+    private Long dropoutCount;          // 낙오자 수
+    private Long activeCount;           // 활성 참여자 수 (낙오자 제외한 나머지)
+    
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
@@ -2,6 +2,7 @@ package com.savit.challenge.mapper;
 
 import com.savit.challenge.domain.ChallengeVO;
 import com.savit.challenge.dto.ChallengeListDTO;
+import com.savit.challenge.dto.ChallengeDropoutSummaryDTO;
 import com.savit.notification.dto.ChallengeNotificationDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -32,4 +33,10 @@ public interface ChallengeMapper {
 
     // 참여중인 챌린지 조회
     List<ChallengeListDTO> findParticipatingChallenges(Long userId);
+
+    // 진행 중인 챌린지별 낙오 요약 통계 조회
+    List<ChallengeDropoutSummaryDTO> getChallengeDropoutSummaries();
+
+    // 특정 챌린지의 FCM 토큰 등록된 참여자 조회
+    List<Long> findParticipantUserIdsByChallengeId(@Param("challengeId") Long challengeId);
 }

--- a/src/main/java/com/savit/notification/domain/PushNotification.java
+++ b/src/main/java/com/savit/notification/domain/PushNotification.java
@@ -1,9 +1,15 @@
 package com.savit.notification.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PushNotification {
     private Long id;
     private Long userId;

--- a/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
+++ b/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
@@ -36,6 +36,7 @@ public class SchedulerTestController {
     private final CardApprovalService cardApprovalService;
     private final NotificationService notificationService;
     private final UserMapper userMapper;
+    private final com.savit.scheduler.job.ChallengeDropoutScheduler challengeDropoutScheduler;
 
     /**
      * 모든 사용자 카드 승인내역 동기화 스케줄러 수동 실행
@@ -215,6 +216,32 @@ public class SchedulerTestController {
         } catch (Exception e) {
             response.put("status", "error");
             response.put("message", "상태 확인 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 챌린지 일일 낙오 요약 알림 테스트
+     */
+    @PostMapping("/challenge-dropout-summary")
+    public ResponseEntity<Map<String, Object>> testChallengeDropoutSummary() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 챌린지 일일 낙오 요약 알림 수동 테스트 시작 ===");
+
+            challengeDropoutScheduler.sendDailyDropoutSummary();
+
+            response.put("status", "success");
+            response.put("message", "챌린지 일일 낙오 요약 알림 발송 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("챌린지 일일 낙오 요약 알림 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
             return ResponseEntity.internalServerError().body(response);
         }
     }

--- a/src/main/java/com/savit/scheduler/job/ChallengeDropoutScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/ChallengeDropoutScheduler.java
@@ -1,0 +1,120 @@
+package com.savit.scheduler.job;
+
+import com.savit.challenge.dto.ChallengeDropoutSummaryDTO;
+import com.savit.challenge.mapper.ChallengeMapper;
+import com.savit.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 챌린지 일일 낙오 요약 알림 스케줄러
+ * - 22:00: 일일 낙오 통계를 집계하여 모든 참여자에게 알림 발송
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeDropoutScheduler {
+
+    private final ChallengeMapper challengeMapper;
+    private final NotificationService notificationService;
+
+    /**
+     * 챌린지별 일일 낙오 요약 알림 발송 (매일 22:00)
+     * 테스트용으로 일단 @Scheduled 주석처리
+     * 실제 운영시 주석 해제해야함
+     */
+//    @Scheduled(cron = "0 0 22 * * *")
+    public void sendDailyDropoutSummary() {
+        log.info("===== 챌린지별 일일 낙오 요약 알림 발송 시작 =====");
+
+        try {
+            // 1. 진행 중인 챌린지별 낙오 통계 조회
+            List<ChallengeDropoutSummaryDTO> challengeSummaries = challengeMapper.getChallengeDropoutSummaries();
+            log.info("진행 중인 챌린지 수: {}개", challengeSummaries.size());
+
+            if (challengeSummaries.isEmpty()) {
+                log.info("현재 진행 중인 챌린지가 없습니다.");
+                return;
+            }
+
+            int totalSentCount = 0;
+
+            // 2. 각 챌린지별로 개별 처리
+            for (ChallengeDropoutSummaryDTO summary : challengeSummaries) {
+                try {
+                    log.info("챌린지 '{}' 처리 시작 - 전체: {}, 낙오: {}, 활성: {}", 
+                            summary.getChallengeTitle(), summary.getTotalParticipants(), 
+                            summary.getDropoutCount(), summary.getActiveCount());
+
+                    // 참여자가 없으면 해당 챌린지 건너뛰기
+                    if (summary.getTotalParticipants() == null || summary.getTotalParticipants() == 0) {
+                        log.info("챌린지 '{}'에 참여자가 없습니다.", summary.getChallengeTitle());
+                        continue;
+                    }
+
+                    // 3. 해당 챌린지의 FCM 토큰 등록된 참여자 조회
+                    List<Long> participantUserIds = challengeMapper.findParticipantUserIdsByChallengeId(summary.getChallengeId());
+                    log.info("챌린지 '{}' 알림 발송 대상: {}명", summary.getChallengeTitle(), participantUserIds.size());
+
+                    if (participantUserIds.isEmpty()) {
+                        log.info("챌린지 '{}'에 FCM 토큰 등록된 참여자가 없습니다.", summary.getChallengeTitle());
+                        continue;
+                    }
+
+                    // 4. 챌린지별 알림 메시지 생성
+                    String message = createChallengeDropoutMessage(summary);
+                    String title = "📊 " + summary.getChallengeTitle() + " 현황";
+
+                    // 5. 해당 챌린지 참여자들에게 알림 발송
+                    int sentCount = 0;
+                    for (Long userId : participantUserIds) {
+                        try {
+                            notificationService.sendNotificationToUser(userId, title, message);
+                            sentCount++;
+                            totalSentCount++;
+
+                            log.debug("사용자 {} 챌린지 '{}' 낙오 요약 알림 발송 완료", userId, summary.getChallengeTitle());
+
+                            // 발송 간격 조절
+                            Thread.sleep(300);
+
+                        } catch (Exception e) {
+                            log.error("사용자 {} 챌린지 '{}' 낙오 요약 알림 발송 실패", userId, summary.getChallengeTitle(), e);
+                        }
+                    }
+
+                    log.info("챌린지 '{}' 알림 발송 완료: {}명", summary.getChallengeTitle(), sentCount);
+
+                } catch (Exception e) {
+                    log.error("챌린지 '{}' 처리 중 오류 발생", summary.getChallengeTitle(), e);
+                }
+            }
+
+            log.info("===== 챌린지별 일일 낙오 요약 알림 발송 완료: 총 {}명 발송 =====", totalSentCount);
+
+        } catch (Exception e) {
+            log.error("챌린지별 일일 낙오 요약 알림 발송 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 챌린지별 낙오 요약 메시지 생성
+     */
+    private String createChallengeDropoutMessage(ChallengeDropoutSummaryDTO summary) {
+        long totalParticipants = summary.getTotalParticipants() != null ? summary.getTotalParticipants() : 0;
+        long dropoutCount = summary.getDropoutCount() != null ? summary.getDropoutCount() : 0;
+        long activeCount = summary.getActiveCount() != null ? summary.getActiveCount() : 0;
+
+        if (dropoutCount == 0) {
+            return String.format("🎉 모든 참여자(%d명)가 잘 진행하고 있어요! 파이팅! 💪", 
+                    totalParticipants);
+        } else {
+            return String.format("📈 전체 %d명 중 %d명 낙오, %d명 여전히 도전 중! 🔥", 
+                    totalParticipants, dropoutCount, activeCount);
+        }
+    }
+}

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -91,7 +91,36 @@
                  inner join challenge as c on cp.challenge_id = c.id
         where cp.user_id = #{userId}
           and cp.status = 'PARTICIPATING'
-        ORDER BY c.start_date asc;
+        ORDER BY c.start_date ASC;
+    </select>
+
+    <!-- 진행 중인 챌린지별 낙오 요약 통계 조회 -->
+    <select id="getChallengeDropoutSummaries" resultType="com.savit.challenge.dto.ChallengeDropoutSummaryDTO">
+        <![CDATA[
+            SELECT
+                c.id as challengeId,
+                c.title as challengeTitle,
+                COUNT(cp.id) as totalParticipants,
+                SUM(CASE WHEN cp.status = 'FAIL' THEN 1 ELSE 0 END) as dropoutCount,
+                (COUNT(cp.id) - SUM(CASE WHEN cp.status = 'FAIL' THEN 1 ELSE 0 END)) as activeCount
+            FROM Challenge c
+            JOIN ChallengeParticipation cp ON c.id = cp.challenge_id
+            WHERE c.start_date <= CURDATE()
+              AND c.end_date >= CURDATE()
+            GROUP BY c.id, c.title
+        ]]>
+    </select>
+
+    <!-- 특정 챌린지의 FCM 토큰 등록된 참여자 조회 -->
+    <select id="findParticipantUserIdsByChallengeId" resultType="Long">
+        <![CDATA[
+            SELECT DISTINCT cp.user_id
+            FROM ChallengeParticipation cp
+            JOIN UserFcmTokens uft ON cp.user_id = uft.user_id
+            WHERE cp.challenge_id = #{challengeId}
+              AND uft.is_active = true
+              AND uft.fcm_token != ''
+        ]]>
     </select>
 
 </mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 각 챌린지별로 개별 통계를 집계하여 해당 챌린지 참여자들에게만 맞춤형 낙오 현황 알림을 발송하는 시스템 구현

## 🔧 주요 변경 사항
- 챌린지 일일 낙오 요약 알림 : 매일 22시에 챌린지별 통계 및 낙오자 현황 발송
예) 📊 한달 배달비 절약 챌린지 현황
         📈 전체 6명 중 2명 낙오, 4명 여전히 도전 중! 🔥

- 챌린지별 낙오 통계 데이터 객체 생성
- 챌린지별 낙오 알림 스케줄러 구현 (현재는 테스트 위해 주석처리 되어있습니다. 실제 운영시 주석 해제 필요합니다!)
- 챌린지별 통계 조회 메서드 추가 및 참여자 조회 쿼리 추가
- 수동 테스트용 API 엔드포인트 추가

- 진행 중인 각 챌린지마다 독립적인 통계 계산
- 참여자는 자신이 참여한 챌린지의 통계만 수신

- DB) PushNotification 테이블에 사용자 정보 저장 (userId 누락 해결)
- PushNotification 도메인 객체 가독성 향상 (빌더 패턴 적용)
(위 2개는 refactor 로 커밋 했습니다... 현재 PR 에 묶여있어요)

- 300ms 발송 간격으로 서버 부하 방지

## 🔔 앞으로 수정할 부분
- 챌린지 관련 알림 중복 발송되는 문제 (발송은 정상 but 같은 알림이 2개)
-> 프론트엔드단에 Service worker 가 직접 처리하도록 data 메세지 방식으로 보내야함을 깨달음...
백엔드에서 실행된 알림 발송 관련 모든 비즈니스 로직과, 스케줄링은 처리하지만  해당 알림을 어떻게 표시할지 프론트엔드가 최종 처리하면 될듯합니다.

## 📌 관련 이슈
- closes #115 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 챌린지별 스케줄러 동작 테스트
- [x] 챌린지별 개별 알림 발송 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함