### PR TITLE
fix: 카드 거래 분류 시 category_name 말고 category_id만 저장하도록 수정 (#119)

### DIFF
--- a/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
@@ -12,8 +12,7 @@ import java.util.Map;
 public interface CardTransactionMapper {
 
     void updateCategory(@Param("transactionId") Long transactionId,
-                        @Param("categoryId") Long categoryId,
-                        @Param("resMemberStoreType") String resMemberStoreType);
+                        @Param("categoryId") Long categoryId);
 
     List<CardTransactionVO> findUnclassifiedTransactionsByUser(@Param("userId") Long userId);
 

--- a/src/main/java/com/savit/card/service/CardTransactionService.java
+++ b/src/main/java/com/savit/card/service/CardTransactionService.java
@@ -70,7 +70,7 @@ public class CardTransactionService {
             return;
         }
 
-        cardTransactionMapper.updateCategory(transactionId, category.getId(), category.getName());
+        cardTransactionMapper.updateCategory(transactionId, category.getId());
     }
 
     // 수동 카테고리 지정
@@ -88,7 +88,7 @@ public class CardTransactionService {
             throw new IllegalArgumentException("해당 카테고리 ID를 찾을 수 없습니다: " + categoryId);
         }
 
-        cardTransactionMapper.updateCategory(transactionId, categoryId, category.getName());
+        cardTransactionMapper.updateCategory(transactionId, categoryId);
     }
 
     // 자동 재분류
@@ -99,7 +99,7 @@ public class CardTransactionService {
         for (CardTransactionVO tx : transactions) {
             try {
                 CategoryVO category = classifyCategory(tx.getResMemberStoreName(), tx.getResMemberStoreType());
-                cardTransactionMapper.updateCategory(tx.getId(), category.getId(), category.getName());
+                cardTransactionMapper.updateCategory(tx.getId(), category.getId());
                 updatedCount++;
             } catch (Exception e) {
                 log.warn("자동 분류 실패 - txId: {}, error: {}", tx.getId(), e.getMessage());

--- a/src/main/resources/mapper/card/CardTransactionMapper.xml
+++ b/src/main/resources/mapper/card/CardTransactionMapper.xml
@@ -23,7 +23,6 @@
     <update id="updateCategory">
         UPDATE CardTransaction
         SET category_id = #{categoryId},
-            res_member_store_type = #{resMemberStoreType},
             updated_at = NOW()
         WHERE id = #{transactionId}
     </update>


### PR DESCRIPTION
## ✅ 작업 내용
- 카드 거래 자동 분류 및 수동 분류 시CardTransaction 테이블에 category name이 아닌 category_id만 저장되도록 로직 수정

## 🔧 주요 변경 사항
- CardTransactionService 자동 분류(autoClassifyTransaction, reclassifyUncategorizedTransactions) 시 categoryId만 저장하도록 변경
- 수동 분류(updateCategory) 로직도 동일하게 정리
- CardTransactionMapper 인터페이스 updateCategory(Long transactionId, Long categoryId) 형태로 변경
- CardTransactionMapper.xml UPDATE 쿼리에서 category_id만 업데이트하도록 수정

## 📌 관련 이슈
- closes #119 

## 🚨 체크리스트
- [ ] 빌드 오류 없음
- [ ] 테스트 코드 작성 또는 실행 확인
- [ ] 커밋 메시지 컨벤션을 지킴
- [ ] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함