### PR TITLE
[feat] 참여중인 챌린지 현황 조회(#120)

### DIFF
--- a/src/main/java/com/savit/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/savit/challenge/controller/ChallengeController.java
@@ -2,8 +2,10 @@ package com.savit.challenge.controller;
 
 import com.savit.challenge.dto.ChallengeDetailDTO;
 import com.savit.challenge.dto.ChallengeListDTO;
+import com.savit.challenge.dto.ChallengeStatusDTO;
 import com.savit.challenge.service.ChallengeService;
 
+import com.savit.challenge.service.ChallengeStatusService;
 import com.savit.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +22,7 @@ import java.util.List;
 public class ChallengeController {
 
     private  final ChallengeService challengeService;
+    private final ChallengeStatusService challengeStatusService;
     private final JwtUtil jwtUtil;
 
     @GetMapping("/available")
@@ -42,5 +45,12 @@ public class ChallengeController {
         List<ChallengeListDTO> result = challengeService.getParticipatingChallenges(userId);
         return ResponseEntity.ok(result);
 
+    }
+
+    @GetMapping("/participating/{challenge_id}")
+    public ResponseEntity<ChallengeStatusDTO> getChallengeStatus(@PathVariable Long challenge_id, HttpServletRequest request) {
+        Long userId = jwtUtil.getUserIdFromToken(request);
+        ChallengeStatusDTO result = challengeStatusService.getChallengeStatus(challenge_id, userId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/savit/challenge/dto/ChallengeStatusDTO.java
+++ b/src/main/java/com/savit/challenge/dto/ChallengeStatusDTO.java
@@ -1,0 +1,25 @@
+package com.savit.challenge.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeStatusDTO {
+    private String title;
+    private Long joinedParticipants;
+    private Long participatingParticipants;
+    private BigDecimal entryFee;
+    private BigDecimal myFee;
+    private String startDate;
+    private String endDate;
+    private BigDecimal expectedPrize;
+    private List<ParticipantInfo> participants;
+
+    private BigDecimal targetAmount;
+    private Long targetCount;
+}

--- a/src/main/java/com/savit/challenge/dto/ParticipantInfo.java
+++ b/src/main/java/com/savit/challenge/dto/ParticipantInfo.java
@@ -1,0 +1,25 @@
+package com.savit.challenge.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ParticipantInfo {
+    private String nickName;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private BigDecimal challengeAmount;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private int challengeCount;
+
+    private String status;
+
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
@@ -2,6 +2,7 @@ package com.savit.challenge.mapper;
 
 import com.savit.challenge.domain.ChallengeVO;
 import com.savit.challenge.dto.ChallengeListDTO;
+import com.savit.challenge.dto.ChallengeStatusDTO;
 import com.savit.notification.dto.ChallengeNotificationDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -11,7 +12,6 @@ import java.util.List;
 
 @Mapper
 public interface ChallengeMapper {
-    List<ChallengeListDTO> getChallengeList();
 
     // 시작일 기준
     List<ChallengeNotificationDTO> findByStartDate(@Param("startDate") LocalDate startDate);
@@ -32,4 +32,10 @@ public interface ChallengeMapper {
 
     // 참여중인 챌린지 조회
     List<ChallengeListDTO> findParticipatingChallenges(Long userId);
+
+    // 챌린지 타입 찾기
+    String selectChallengeType(Long challengeId);
+
+    //챌린지 현황 조회
+    ChallengeStatusDTO selectChallengeStatus(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
@@ -1,9 +1,11 @@
 package com.savit.challenge.mapper;
 
+import com.savit.challenge.dto.ParticipantInfo;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Mapper
 public interface ChallengeParticipationMapper {
@@ -13,4 +15,6 @@ public interface ChallengeParticipationMapper {
     void insertParticipation(@Param("challengeId") Long challengeId,
                              @Param("userId") Long userId,
                              @Param("myFee") BigDecimal myFee);
+    List<ParticipantInfo> selectParticipantsWithAmount(Long challengeId);
+    List<ParticipantInfo> selectParticipantsWithCount(Long challengeId);
 }

--- a/src/main/java/com/savit/challenge/service/ChallengeStatusService.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeStatusService.java
@@ -1,0 +1,14 @@
+package com.savit.challenge.service;
+
+import com.savit.challenge.dto.ChallengeStatusDTO;
+import com.savit.challenge.mapper.ChallengeMapper;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface ChallengeStatusService {
+    ChallengeStatusDTO  getChallengeStatus(Long challengeId, Long userId);
+
+
+
+}

--- a/src/main/java/com/savit/challenge/service/ChallengeStatusServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeStatusServiceImpl.java
@@ -1,0 +1,45 @@
+package com.savit.challenge.service;
+
+import com.savit.challenge.dto.ChallengeStatusDTO;
+import com.savit.challenge.dto.ParticipantInfo;
+import com.savit.challenge.mapper.ChallengeMapper;
+import com.savit.challenge.mapper.ChallengeParticipationMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeStatusServiceImpl implements ChallengeStatusService {
+
+    private final ChallengeMapper challengeMapper;
+    private final ChallengeParticipationMapper participationMapper;
+
+    @Override
+    public ChallengeStatusDTO  getChallengeStatus(Long challengeId, Long userId) {
+        // 1. 우선 메인 현황 정보들 가져오기
+        ChallengeStatusDTO mainInfo = challengeMapper.selectChallengeStatus(challengeId, userId);
+
+        // 2. challenge 타입 확인 후 참여자 목록 조회
+        String type = challengeMapper.selectChallengeType(challengeId);
+
+        List<ParticipantInfo> participants;
+        if ("AMOUNT".equals(type)) {
+            participants = participationMapper.selectParticipantsWithAmount(challengeId);
+              mainInfo.setTargetCount(null);
+        } else {
+            participants = participationMapper.selectParticipantsWithCount(challengeId);
+            mainInfo.setTargetAmount(null);
+        }
+        mainInfo.setParticipants(participants);
+
+        return mainInfo;
+    }
+
+
+}

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -94,4 +94,34 @@
         ORDER BY c.start_date asc;
     </select>
 
+    <select id="selectChallengeType" resultType="java.lang.String">
+        select type from challenge where id = #{challengeId}
+    </select>
+
+    <!--현황 조회-->
+    <select id="selectChallengeStatus" resultType="com.savit.challenge.dto.ChallengeStatusDTO">
+        SELECT c.title,
+               DATE_FORMAT(c.start_date, '%Y-%m-%d') AS startDate,
+               DATE_FORMAT(c.end_date, '%Y-%m-%d') AS endDate,
+               c.target_amount AS targetAmount,
+               c.target_count AS targetCount,
+               c.type,
+               COUNT(cp.id) AS joinedParticipants,
+               COUNT(CASE WHEN cp.status = 'PARTICIPATING' THEN 1 END) AS participatingParticipants,
+               SUM(cp.my_fee) AS entryFee,
+               MAX(CASE WHEN cp.user_id = #{userId} THEN cp.my_fee END) AS myFee,
+               CASE
+                   WHEN COUNT(CASE WHEN cp.status = 'PARTICIPATING' THEN 1 END) = 0 THEN 0
+                   ELSE ROUND(
+                           SUM(CASE WHEN cp.status = 'FAIL' THEN cp.my_fee ELSE 0 END) /
+                           COUNT(CASE WHEN cp.status = 'PARTICIPATING' THEN 1 END),
+                           2
+                        )
+                   END AS expectedPrize
+        FROM Challenge c
+                 LEFT JOIN ChallengeParticipation cp ON c.id = cp.challenge_id
+        WHERE c.id = #{challengeId}
+        GROUP BY c.id, c.title, c.start_date, c.end_date, c.target_amount, c.target_count, c.type
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
@@ -19,4 +19,24 @@
                  )
     </insert>
 
+    <!-- challenge 타입 amount 일때, 참여자들 현황 -->
+    <select id="selectParticipantsWithAmount" resultType="com.savit.challenge.dto.ParticipantInfo">
+        select u.nickname          as nickName,
+               cp.challenge_amount as challengeAmount,
+               cp.status
+        from challengeParticipation as cp
+                 inner join user as u
+                            on cp.user_id = u.id
+        where cp.challenge_id = #{challengeId}
+    </select>
+
+    <!-- challenge 타입 count 일때, 참여자들 현황-->
+    <select id="selectParticipantsWithCount" resultType="com.savit.challenge.dto.ParticipantInfo">
+        select u.nickname as nickName, cp.challenge_count as challengeCount, cp.status
+        from challengeParticipation as cp
+                 inner join user as u on cp.user_id = u.id
+        where cp.challenge_id = #{challengeId}
+    </select>
+
+
 </mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 참여중인 챌린지 현황 조회 기능 구현 (api/challenge/participating/{challenge_id}

## 🔧 주요 변경 사항
- ChallengeController: getChallengeStatus(challenge_id)
- ChallengeStatusService: getChallengeStatus(challenge_id, user_id)
- ChallengeMapper: selectChallengeStatus(), selectChallengeType()
- ChallengeParticipationMapper: selectParticipantsWithAmount(), selectParticipantsWithCount()
- ChallengeStatusDTO: 챌린지 현황 응답 구조
- ParticipantInfo: 참여자별 진행 현황 구조

## 📌 관련 이슈
- closes #120 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함