### PR TITLE
[feat] 결제 검증 API에 사용자 식별 로직 추가 (#126)

### DIFF
--- a/src/main/java/com/savit/challenge/controller/PaymentVerificationController.java
+++ b/src/main/java/com/savit/challenge/controller/PaymentVerificationController.java
@@ -1,11 +1,13 @@
 package com.savit.challenge.controller;
 
 import com.savit.challenge.service.IamportService;
+import com.savit.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 @RestController
@@ -15,11 +17,16 @@ import java.util.Map;
 public class PaymentVerificationController {
 
     private final IamportService iamportService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/verify")
-    public ResponseEntity<String> verifyDirectly(@RequestBody Map<String, String> body) {
-        String impUid = body.get("impUid");
+    public ResponseEntity<String> verifyDirectly(
+            @RequestBody Map<String, String> body,
+            HttpServletRequest request
+    ) {
+        Long userId = jwtUtil.getUserIdFromToken(request);
 
+        String impUid = body.get("impUid");
         log.info("========= [Verify] 받은 imp_uid: {}", impUid);
 
         try {


### PR DESCRIPTION
## ✅ 작업 내용
- `verifyDirectly` 메서드에 `jwtUtil.getUserIdFromToken(request)` 호출 추가
- 사용자 ID를 로그 및 결제 검증 전 처리에서 활용 가능하도록 변경

## 🔧 주요 변경 사항
- `PaymentVerificationController` 수정
- 
## 📌 관련 이슈
- closes #126 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함