### PR TITLE
[feat] 챌린지 통계 페이지 기능 구현(#125)

### DIFF
--- a/src/main/java/com/savit/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/savit/challenge/controller/ChallengeController.java
@@ -1,8 +1,10 @@
 package com.savit.challenge.controller;
 
+import com.google.api.Http;
 import com.savit.challenge.dto.ChallengeDetailDTO;
 import com.savit.challenge.dto.ChallengeListDTO;
 import com.savit.challenge.dto.ChallengeStatusDTO;
+import com.savit.challenge.dto.ChallengeSummaryDTO;
 import com.savit.challenge.service.ChallengeService;
 
 import com.savit.challenge.service.ChallengeStatusService;
@@ -53,4 +55,13 @@ public class ChallengeController {
         ChallengeStatusDTO result = challengeStatusService.getChallengeStatus(challenge_id, userId);
         return ResponseEntity.ok(result);
     }
+
+    @GetMapping("/stats")
+    public ResponseEntity<List<ChallengeSummaryDTO>> getChallengeSummary(HttpServletRequest request) {
+        Long userId = jwtUtil.getUserIdFromToken(request);
+        List<ChallengeSummaryDTO> result = challengeService.getChallengeSummary(userId);
+        return ResponseEntity.ok(result);
+
+    }
+
 }

--- a/src/main/java/com/savit/challenge/dto/ChallengeSummaryDTO.java
+++ b/src/main/java/com/savit/challenge/dto/ChallengeSummaryDTO.java
@@ -1,0 +1,22 @@
+package com.savit.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeSummaryDTO {
+    private Long challengeId;
+    private String title;
+    private String startDate;
+    private String endDate;
+    private String status;
+    private BigDecimal my_fee;
+    private BigDecimal prize;
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
@@ -1,5 +1,6 @@
 package com.savit.challenge.mapper;
 
+import com.savit.challenge.dto.ChallengeSummaryDTO;
 import com.savit.challenge.dto.ParticipantInfo;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -21,4 +22,6 @@ public interface ChallengeParticipationMapper {
   
     List<ParticipantInfo> selectParticipantsWithAmount(Long challengeId);
     List<ParticipantInfo> selectParticipantsWithCount(Long challengeId);
+
+    List<ChallengeSummaryDTO>  selectChallengeSummary(Long userId);
 }

--- a/src/main/java/com/savit/challenge/service/ChallengeService.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeService.java
@@ -3,6 +3,7 @@ package com.savit.challenge.service;
 import com.savit.challenge.domain.ChallengeVO;
 import com.savit.challenge.dto.ChallengeDetailDTO;
 import com.savit.challenge.dto.ChallengeListDTO;
+import com.savit.challenge.dto.ChallengeSummaryDTO;
 
 import java.util.List;
 
@@ -13,4 +14,5 @@ public interface ChallengeService {
 
     List<ChallengeListDTO> getParticipatingChallenges (Long userId);
 
+    List<ChallengeSummaryDTO> getChallengeSummary(Long userId);
 }

--- a/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
@@ -7,6 +7,7 @@ import com.savit.card.mapper.CardTransactionMapper;
 import com.savit.challenge.domain.ChallengeVO;
 import com.savit.challenge.dto.ChallengeDetailDTO;
 import com.savit.challenge.dto.ChallengeListDTO;
+import com.savit.challenge.dto.ChallengeSummaryDTO;
 import com.savit.challenge.mapper.ChallengeMapper;
 import com.savit.challenge.mapper.ChallengeParticipationMapper;
 import lombok.RequiredArgsConstructor;
@@ -129,4 +130,10 @@ public class ChallengeServiceImpl implements ChallengeService {
     public List<ChallengeListDTO> getParticipatingChallenges(Long userId) {
         return challengeMapper.findParticipatingChallenges(userId);
     }
+
+    @Override
+    public List<ChallengeSummaryDTO> getChallengeSummary(Long userId) {
+        return challengeParticipationMapper.selectChallengeSummary(userId);
+    }
+
 }

--- a/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
@@ -43,5 +43,12 @@
         where cp.challenge_id = #{challengeId}
     </select>
 
+    <select id="selectChallengeSummary" resultType="com.savit.challenge.dto.ChallengeSummaryDTO">
+        select cp.challenge_id, c.title, c.start_date,  c.end_date,
+           cp.status, cp.my_fee, cp.prize
+        from challengeParticipation as cp join challenge as c on cp.challenge_id =c.id
+        where cp.user_id = #{userId}  and cp.status IN ('SUCCESS', 'FAIL')
+    </select>
+
 
 </mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 사용자의 챌린지 중 status가 success와 fail인 것 반호나
- challengestatus 와 혼동 방지 위해 challengeSummary 로 표기( api는 stats)
- 
## 🔧 주요 변경 사항
- challengeSummaryDTO
- challengeController: getChallengeSummary
- challengeService/ServiceImpl: getChallengeSummary
- challengParticipationMapper/Mapper.xml: selectChallengeSummary

## 📌 관련 이슈
- closes #125 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함