### PR TITLE
[fix] 리눅스 환경 대응을 위한 XML 테이블명 대문자 수정 (#129)

### DIFF
--- a/src/main/resources/mapper/budget/BudgetCategoryMapper.xml
+++ b/src/main/resources/mapper/budget/BudgetCategoryMapper.xml
@@ -4,16 +4,16 @@
 
 
     <insert id="insertBudgetCategory">
-        INSERT INTO budgetcategory (target_amount, budget_id, category_id)
+        INSERT INTO Budgetcategory (target_amount, budget_id, category_id)
         VALUES ( #{targetAmount}, #{budgetId},#{categoryId})
     </insert>
     <update id="updateBudgetCategory">
-        update budgetcategory set target_amount = #{targetAmount}
+        update Budgetcategory set target_amount = #{targetAmount}
         where budget_id = #{budgetId} and category_id = #{categoryId}
     </update>
 
     <select id="getBudgetCategories" resultType="com.savit.budget.domain.BudgetCategoryVO">
-        SELECT * FROM budgetcategory
+        SELECT * FROM Budgetcategory
         WHERE budget_id = #{budgetId}
         <if test="categoryIds != null and categoryIds.size() > 0">
             AND category_id IN

--- a/src/main/resources/mapper/budget/BudgetMapper.xml
+++ b/src/main/resources/mapper/budget/BudgetMapper.xml
@@ -4,16 +4,16 @@
 
 
     <insert id="insertBudget" >
-        INSERT INTO budget (user_id, month, total_budget)
+        INSERT INTO Budget (user_id, month, total_budget)
         values (#{userId}, #{month}, #{totalBudget})
     </insert>
     <update id="updateBudget">
-        update budget
+        update Budget
         set total_budget = #{totalBudget}
             where user_id = #{userId} AND month = #{month}
     </update>
     <select id="getBudget" resultType="com.savit.budget.domain.BudgetVO">
-        Select * from budget where user_id = #{userId} and month = #{month}
+        Select * from Budget where user_id = #{userId} and month = #{month}
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/budget/CategoryMapper.xml
+++ b/src/main/resources/mapper/budget/CategoryMapper.xml
@@ -6,11 +6,11 @@
 <mapper namespace="com.savit.budget.mapper.CategoryMapper">
 
     <select id="findById" parameterType="long" resultType="com.savit.budget.domain.CategoryVO">
-        SELECT * FROM category WHERE id = #{id}
+        SELECT * FROM Category WHERE id = #{id}
     </select>
 
     <select id="findByName" parameterType="string" resultType="com.savit.budget.domain.CategoryVO">
-        SELECT * FROM category WHERE name = #{name}
+        SELECT * FROM Category WHERE name = #{name}
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -5,13 +5,12 @@
     <!-- 1번. 사용자 1주 챌린지 성공 여부 + category_id 조회 -->
     <select id="findSuccessfulWeeklyCategories" resultType="Long">
         select distinct c.category_id
-        from challengeparticipation as cp
-                 inner join challenge as c on cp.challenge_id = c.id
+        from ChallengeParticipation as cp
+                 inner join Challenge as c on cp.challenge_id = c.id
         where cp.user_id = #{userId}
           and cp.status = 'SUCCESS'
           and c.duration_weeks = 1
     </select>
-
 
     <!-- 알림용 챌린지 시작일 쿼리 -->
     <select id="findByStartDate" parameterType="java.time.LocalDate" resultType="com.savit.notification.dto.ChallengeNotificationDTO">
@@ -43,12 +42,11 @@
           AND status = 'PARTICIPATING'
     </select>
 
-    <!--참여 가능한 1주 챌린지 목록 조회(1번 여부 상관 없이 조회됨)-->
+    <!-- 참여 가능한 1주 챌린지 목록 조회 -->
     <select id="findWeeklyChallenges" resultType="com.savit.challenge.dto.ChallengeListDTO">
         select c.id as challenge_id, c.title, c.start_date, c.end_date, cat.name as categoryName
-        from challenge c
-                 inner join
-             category as cat on c.category_id = cat.id
+        from Challenge c
+                 inner join Category as cat on c.category_id = cat.id
         where current_date &lt;  c.start_date
           and c.duration_weeks = 1
         order by c.start_date asc
@@ -57,18 +55,15 @@
     <!-- 1번 기준 충족시 4주 챌린지 목록 조회 -->
     <select id="findMonthlyChallenges" resultType="com.savit.challenge.dto.ChallengeListDTO">
         select c.id as challenge_id, c.title, c.start_date, c.end_date, cat.name as categoryName
-        from challenge c
-                 inner join
-             category as cat on c.category_id = cat.id
+        from Challenge c
+                 inner join Category as cat on c.category_id = cat.id
         where current_date &lt;  c.start_date
           and c.duration_weeks = 4
           and c.category_id = #{categoryId}
         order by c.start_date asc
-
-
     </select>
-    <select id="findById" resultType="com.savit.challenge.domain.ChallengeVO">
 
+    <select id="findById" resultType="com.savit.challenge.domain.ChallengeVO">
         select id,
                title,
                description,
@@ -81,15 +76,14 @@
                type,
                duration_weeks,
                category_id
-        from challenge
+        from Challenge
         where id = #{id}
     </select>
 
-
     <select id="findParticipatingChallenges" resultType="com.savit.challenge.dto.ChallengeListDTO">
         select cp.challenge_id, c.title, c.start_date, c.end_date
-        from challengeParticipation as cp
-                 inner join challenge as c on cp.challenge_id = c.id
+        from ChallengeParticipation as cp
+                 inner join Challenge as c on cp.challenge_id = c.id
         where cp.user_id = #{userId}
           and cp.status = 'PARTICIPATING'
         ORDER BY c.start_date ASC;
@@ -98,37 +92,37 @@
     <!-- 진행 중인 챌린지별 낙오 요약 통계 조회 -->
     <select id="getChallengeDropoutSummaries" resultType="com.savit.challenge.dto.ChallengeDropoutSummaryDTO">
         <![CDATA[
-            SELECT
-                c.id as challengeId,
-                c.title as challengeTitle,
-                COUNT(cp.id) as totalParticipants,
-                SUM(CASE WHEN cp.status = 'FAIL' THEN 1 ELSE 0 END) as dropoutCount,
-                (COUNT(cp.id) - SUM(CASE WHEN cp.status = 'FAIL' THEN 1 ELSE 0 END)) as activeCount
-            FROM Challenge c
-            JOIN ChallengeParticipation cp ON c.id = cp.challenge_id
-            WHERE c.start_date <= CURDATE()
-              AND c.end_date >= CURDATE()
-            GROUP BY c.id, c.title
+        SELECT
+            c.id as challengeId,
+            c.title as challengeTitle,
+            COUNT(cp.id) as totalParticipants,
+            SUM(CASE WHEN cp.status = 'FAIL' THEN 1 ELSE 0 END) as dropoutCount,
+            (COUNT(cp.id) - SUM(CASE WHEN cp.status = 'FAIL' THEN 1 ELSE 0 END)) as activeCount
+        FROM Challenge c
+                 JOIN ChallengeParticipation cp ON c.id = cp.challenge_id
+        WHERE c.start_date <= CURDATE()
+          AND c.end_date >= CURDATE()
+        GROUP BY c.id, c.title
         ]]>
     </select>
 
     <!-- 특정 챌린지의 FCM 토큰 등록된 참여자 조회 -->
     <select id="findParticipantUserIdsByChallengeId" resultType="Long">
         <![CDATA[
-            SELECT DISTINCT cp.user_id
-            FROM ChallengeParticipation cp
-            JOIN UserFcmTokens uft ON cp.user_id = uft.user_id
-            WHERE cp.challenge_id = #{challengeId}
-              AND uft.is_active = true
-              AND uft.fcm_token != ''
+        SELECT DISTINCT cp.user_id
+        FROM ChallengeParticipation cp
+                 JOIN UserFcmTokens uft ON cp.user_id = uft.user_id
+        WHERE cp.challenge_id = #{challengeId}
+          AND uft.is_active = true
+          AND uft.fcm_token != ''
         ]]>
     </select>
 
     <select id="selectChallengeType" resultType="java.lang.String">
-        select type from challenge where id = #{challengeId}
+        select type from Challenge where id = #{challengeId}
     </select>
 
-    <!--현황 조회-->
+    <!-- 현황 조회 -->
     <select id="selectChallengeStatus" resultType="com.savit.challenge.dto.ChallengeStatusDTO">
         SELECT c.title,
                DATE_FORMAT(c.start_date, '%Y-%m-%d') AS startDate,

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -20,26 +20,26 @@
     <!-- 이메일로 사용자 조회 -->
     <select id="findByEmail" parameterType="String" resultMap="userResultMap">
         SELECT id, email, nickname, profile_image, created_at, updated_at, kakao_user_id
-        FROM user
+        FROM User
         WHERE email = #{email}
     </select>
 
     <!-- 카카오 사용자 ID로 사용자 조회 -->
     <select id="findByKakaoUserId" parameterType="String" resultMap="userResultMap">
         SELECT id, email, nickname, profile_image, created_at, updated_at, kakao_user_id
-        FROM user
+        FROM User
         WHERE kakao_user_id = #{kakaoUserId}
     </select>
 
     <!-- 사용자 생성 -->
     <insert id="insertUser" parameterType="com.savit.user.domain.User" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO user (email, nickname, profile_image, created_at, updated_at, kakao_user_id, connected_id, refresh_token, birth_date)
+        INSERT INTO User (email, nickname, profile_image, created_at, updated_at, kakao_user_id, connected_id, refresh_token, birth_date)
         VALUES (#{email}, #{nickname}, #{profileImage}, #{createdAt}, #{updatedAt}, #{kakaoUserId}, #{connectedId}, #{refreshToken}, #{birthDate})
     </insert>
 
     <!-- 사용자 정보 업데이트 -->
     <update id="updateUser" parameterType="com.savit.user.domain.User">
-        UPDATE user
+        UPDATE User
         SET nickname = #{nickname},
         profile_image = #{profileImage},
         updated_at = #{updatedAt},


### PR DESCRIPTION
## 🐞 어떤 문제인가요?
EC2 (Linux) 환경에서는 MySQL이 **테이블명을 대소문자 구분**합니다.  
기존 MyBatis XML Mapper에는 테이블명이 소문자가 아닌 **대문자(User, ChallengeParticipation 등)** 로 작성된 부분이 있어 **배포 환경에서 "table doesn't exist" 오류**가 발생했습니다.

## ✅ 해결 방안
- XML Mapper 파일 내 테이블명을 실제 데이터베이스에 맞춰 **대문자 → 정확한 대소문자**로 수정했습니다.
- EC2 환경에서도 정상적으로 테이블을 인식할 수 있도록 수정했습니다.

## 🔍 대상 파일
- `UserMapper.xml`
- `ChallengeMapper.xml`
- (기타 관련된 XML Mapper에서 대소문자 문제 있는 테이블 전반)

## 📌 참고
- macOS나 Windows의 MySQL은 기본적으로 **대소문자를 구분하지 않지만**, Linux는 기본적으로 구분합니다.
- [MySQL 공식문서 - lower_case_table_names](https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html)

## 📌 관련 이슈
- closes #129 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [ ] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함