### PR TITLE
[feat] 챌린지 시작/종료 하루 전 알림 기능 구현 (#108)

### DIFF
--- a/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
+++ b/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
@@ -4,8 +4,11 @@ import com.savit.budget.service.BudgetMonitoringService;
 import com.savit.card.dto.BudgetMonitoringDTO;
 import com.savit.card.service.AsyncCardApprovalService;
 import com.savit.card.service.CardApprovalService;
-import com.savit.notification.service.NotificationService;
-import com.savit.scheduler.job.*;
+import com.savit.scheduler.job.CardApprovalScheduler;
+import com.savit.scheduler.job.RandomNaggingScheduler;
+import com.savit.scheduler.job.ChallengeDropoutScheduler;
+import com.savit.scheduler.job.DailyTopSpendingScheduler;
+import com.savit.scheduler.job.ChallengeScheduleNotificationScheduler;
 import com.savit.user.mapper.UserMapper;
 import com.savit.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +36,7 @@ public class SchedulerTestController {
     private final AsyncCardApprovalService asyncCardApprovalService;
     private final BudgetMonitoringService budgetMonitoringService;
     private final CardApprovalService cardApprovalService;
-    private final NotificationService notificationService;
     private final UserMapper userMapper;
-
     private final ChallengeDropoutScheduler challengeDropoutScheduler;
     private final DailyTopSpendingScheduler dailyTopSpendingScheduler;
     private final ChallengeScheduleNotificationScheduler challengeScheduleNotificationScheduler;

--- a/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
+++ b/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
@@ -5,10 +5,7 @@ import com.savit.card.dto.BudgetMonitoringDTO;
 import com.savit.card.service.AsyncCardApprovalService;
 import com.savit.card.service.CardApprovalService;
 import com.savit.notification.service.NotificationService;
-import com.savit.scheduler.job.CardApprovalScheduler;
-import com.savit.scheduler.job.RandomNaggingScheduler;
-import com.savit.scheduler.job.ChallengeDropoutScheduler;
-import com.savit.scheduler.job.DailyTopSpendingScheduler;
+import com.savit.scheduler.job.*;
 import com.savit.user.mapper.UserMapper;
 import com.savit.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +38,7 @@ public class SchedulerTestController {
 
     private final ChallengeDropoutScheduler challengeDropoutScheduler;
     private final DailyTopSpendingScheduler dailyTopSpendingScheduler;
+    private final ChallengeScheduleNotificationScheduler challengeScheduleNotificationScheduler;
 
 
     /**
@@ -297,6 +295,32 @@ public class SchedulerTestController {
 
         } catch (Exception e) {
             log.error("일일 최고 지출 알림 발송 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
+     * 챌린지 시작/종료 하루 전 알림 테스트 (수동 실행)
+     */
+    @PostMapping("/challenge/schedule-notification")
+    public ResponseEntity<Map<String, Object>> testChallengeScheduleNotification() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 챌린지 일정 알림 스케줄러 수동 테스트 시작 ===");
+
+            challengeScheduleNotificationScheduler.sendChallengeScheduleNotifications();
+
+            response.put("status", "success");
+            response.put("message", "챌린지 일정 알림 스케줄러 실행 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("챌린지 일정 알림 테스트 실패", e);
             response.put("status", "error");
             response.put("message", "실행 실패: " + e.getMessage());
             return ResponseEntity.internalServerError().body(response);

--- a/src/main/java/com/savit/scheduler/job/ChallengeScheduleNotificationScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/ChallengeScheduleNotificationScheduler.java
@@ -1,0 +1,64 @@
+package com.savit.scheduler.job;
+
+import com.savit.notification.dto.ChallengeNotificationDTO;
+import com.savit.challenge.mapper.ChallengeMapper;
+import com.savit.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeScheduleNotificationScheduler {
+
+    private final ChallengeMapper challengeMapper;
+    private final NotificationService notificationService;
+
+    @Scheduled(cron = "0 0 22 * * *") // 매일 밤 22시
+    public void sendChallengeScheduleNotifications() {
+        log.info("===== 챌린지 일정 알림 스케줄러 시작 =====");
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+
+        try {
+            // 내일 시작 챌린지
+            List<ChallengeNotificationDTO> starting = challengeMapper.findByStartDate(tomorrow);
+            for (ChallengeNotificationDTO challenge : starting) {
+                notify(challenge, true);
+            }
+
+            // 내일 종료 챌린지
+            List<ChallengeNotificationDTO> ending = challengeMapper.findByEndDate(tomorrow);
+            for (ChallengeNotificationDTO challenge : ending) {
+                notify(challenge, false);
+            }
+
+            log.info("===== 챌린지 일정 알림 스케줄러 완료 =====");
+        } catch (Exception e) {
+            log.error("챌린지 일정 알림 스케줄러 오류 발생", e);
+        }
+    }
+
+    private void notify(ChallengeNotificationDTO challenge, boolean isStart) {
+        List<Long> userIds = challengeMapper.findUserIdsByChallengeId(challenge.getChallengeId());
+        String title = isStart ?
+                "🔥 [" + challenge.getTitle() + "] 내일 시작합니다!" :
+                "⏰ [" + challenge.getTitle() + "] 내일 종료됩니다!";
+        String body = isStart ?
+                "준비되셨나요? 내일 새로운 도전이 시작됩니다 💪" :
+                "내일이 마지막 날입니다! 목표를 꼭 달성하세요 🏁";
+
+        for (Long userId : userIds) {
+            notificationService.sendNotificationToUser(userId, title, body);
+        }
+    }
+
+    @Scheduled(cron = "0 1 22 * * *") // 매일 22시 1분 스케쥴러 체크
+    public void schedulerHealthCheck() {
+        log.debug("챌린지 일정 알림 스케줄러 상태 체크 - 정상 동작 중");
+    }
+}


### PR DESCRIPTION
## ✅ 작업 내용
- 챌린지 시작/종료 하루 전 푸시 알림 스케줄러 구현
- 테스트 컨트롤러에서 수동 실행 가능하도록 API 추가

## 🔧 주요 변경 사항
- ChallengeScheduleNotificationScheduler.java: 매일 22시에 챌린지 시작/종료 하루 전 사용자에게 푸시 발송
- SchedulerTestController.java: /api/test/scheduler/challenge/schedule-notification 수동 테스트용 API 추가

## 📌 관련 이슈
- closes #108 

## 🚨 체크리스트
- [ ] 빌드 오류 없음
- [ ] 테스트 코드 작성 또는 실행 확인
- [ ] 커밋 메시지 컨벤션을 지킴
- [ ] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함