### PR TITLE
fix: 토큰 만료 401 에러로 나오도록 변경 (#135)

### DIFF
--- a/src/main/java/com/savit/security/JwtTokenProvider.java
+++ b/src/main/java/com/savit/security/JwtTokenProvider.java
@@ -38,7 +38,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-
     // refresh token 생성
     public String createRefreshToken(String userId) {
         Claims claims = Jwts.claims().setSubject(userId);
@@ -66,34 +65,47 @@ public class JwtTokenProvider {
                 .build();
     }
 
-   // 토큰에서 userid 추출
+    // 토큰에서 userid 추출 (만료된 토큰도 처리)
     public String getUserId(String token) {
         try {
-           return Jwts.parser()
+            return Jwts.parser()
                     .setSigningKey(secretKey)
                     .parseClaimsJws(token)
                     .getBody()
                     .getSubject();
-        }  catch (ExpiredJwtException e) {
-            throw new JwtTokenException("토큰이 만료되었습니다");
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰에서도 userId 추출 가능
+            return e.getClaims().getSubject();
         } catch (JwtException | IllegalArgumentException e) {
             throw new JwtTokenException("유효하지 않은 토큰입니다");
         }
     }
 
-    // 토큰 유효성 검증
+    // 토큰 유효성 검증 (만료 여부만 체크, 예외 던지지 않음)
     public boolean validateToken(String token) {
         try {
             Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
             return true;
-        } catch  (ExpiredJwtException e) {
-            throw new JwtTokenException("토큰이 만료되었습니다");
+        } catch (ExpiredJwtException e) {
+            return false;  // 만료된 토큰은 false 반환
         } catch (JwtException | IllegalArgumentException e) {
-            throw new JwtTokenException("유효하지 않은 토큰입니다");
+            return false;  // 유효하지 않은 토큰은 false 반환
         }
     }
 
-    // access token 인지 확인
+    // 토큰이 만료되었는지 확인 (만료 여부만 체크)
+    public boolean isTokenExpired(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return false;  // 파싱 성공하면 만료되지 않음
+        } catch (ExpiredJwtException e) {
+            return true;   // 만료된 토큰
+        } catch (JwtException | IllegalArgumentException e) {
+            return true;   // 유효하지 않은 토큰도 만료로 처리
+        }
+    }
+
+    // access token 인지 확인 (만료된 토큰도 처리)
     public boolean isAccessToken(String token) {
         try {
             Claims claims = Jwts.parser()
@@ -102,13 +114,14 @@ public class JwtTokenProvider {
                     .getBody();
             return "access".equals(claims.get("type"));
         } catch (ExpiredJwtException e) {
-            throw new JwtTokenException("토큰이 만료되었습니다");
+            // 만료된 토큰에서도 타입 확인 가능
+            return "access".equals(e.getClaims().get("type"));
         } catch (Exception e) {
-            throw new JwtTokenException("토큰 타입을 확인할 수 없습니다");
+            return false;  // 예외 발생시 false 반환
         }
     }
 
-    // refresh token 인지 확인
+    // refresh token 인지 확인 (만료된 토큰도 처리)
     public boolean isRefreshToken(String token) {
         try {
             Claims claims = Jwts.parser()
@@ -117,22 +130,30 @@ public class JwtTokenProvider {
                     .getBody();
             return "refresh".equals(claims.get("type"));
         } catch (ExpiredJwtException e) {
-            throw new JwtTokenException("토큰이 만료되었습니다");
+            // 만료된 토큰에서도 타입 확인 가능
+            return "refresh".equals(e.getClaims().get("type"));
         } catch (Exception e) {
-            throw new JwtTokenException("토큰 타입을 확인할 수 없습니다");
+            return false;  // 예외 발생시 false 반환
         }
     }
 
-   // 토큰 만료 시간
+    // 토큰 만료 시간 (만료된 토큰도 처리)
     public Date getExpirationDate(String token) {
-        return Jwts.parser()
-                .setSigningKey(secretKey)
-                .parseClaimsJws(token)
-                .getBody()
-                .getExpiration();
+        try {
+            return Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰에서도 만료일 반환 가능
+            return e.getClaims().getExpiration();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new JwtTokenException("유효하지 않은 토큰입니다.");
+        }
     }
 
-    // 토큰이 곧 만료되는지(30분)
+    // 토큰이 곧 만료되는지(30분) - 안전한 버전
     public boolean isTokenExpiringSoon(String token) {
         try {
             Date expiration = getExpirationDate(token);
@@ -142,8 +163,48 @@ public class JwtTokenProvider {
             // 30분 이내에 만료되면 true
             return timeDiff < (30 * 60 * 1000);
         } catch (Exception e) {
-            return true;
+            return true;  // 예외 발생시 만료 임박으로 처리
         }
     }
 
+    // 토큰 상태를 종합적으로 검증하는 메서드 추가
+    public TokenValidationResult validateTokenWithDetails(String token) {
+        if (token == null || token.trim().isEmpty()) {
+            return TokenValidationResult.builder()
+                    .valid(false)
+                    .expired(false)
+                    .message("토큰이 없습니다")
+                    .build();
+        }
+
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return TokenValidationResult.builder()
+                    .valid(true)
+                    .expired(false)
+                    .message("유효한 토큰입니다")
+                    .build();
+        } catch (ExpiredJwtException e) {
+            return TokenValidationResult.builder()
+                    .valid(false)
+                    .expired(true)
+                    .message("토큰이 만료되었습니다")
+                    .build();
+        } catch (JwtException | IllegalArgumentException e) {
+            return TokenValidationResult.builder()
+                    .valid(false)
+                    .expired(false)
+                    .message("유효하지 않은 토큰입니다")
+                    .build();
+        }
+    }
+
+    // 토큰 검증 결과를 담는 내부 클래스
+    @lombok.Builder
+    @lombok.Getter
+    public static class TokenValidationResult {
+        private boolean valid;
+        private boolean expired;
+        private String message;
+    }
 }

--- a/src/main/java/com/savit/security/JwtUtil.java
+++ b/src/main/java/com/savit/security/JwtUtil.java
@@ -13,7 +13,7 @@ public class JwtUtil {
     private final JwtTokenProvider jwtTokenProvider;
 
     /**
-     * HttpServletRequest에서 userId 추출
+     * HttpServletRequest에서 userId 추출 (안전한 버전)
      */
     public Long getUserIdFromToken(HttpServletRequest request) {
         String token = extractTokenFromRequest(request);
@@ -22,16 +22,34 @@ public class JwtUtil {
             throw new JwtTokenException("토큰이 없습니다.");
         }
 
-        if (!jwtTokenProvider.validateToken(token)) {
-            throw new JwtTokenException("유효하지 않은 토큰입니다.");
+        // 토큰 상태 종합 검증
+        JwtTokenProvider.TokenValidationResult validationResult =
+                jwtTokenProvider.validateTokenWithDetails(token);
+
+        if (!validationResult.isValid()) {
+            if (validationResult.isExpired()) {
+                throw new JwtTokenException("토큰이 만료되었습니다.");
+            } else {
+                throw new JwtTokenException("유효하지 않은 토큰입니다.");
+            }
         }
 
+        // Access Token 확인 (만료된 토큰도 안전하게 처리)
         if (!jwtTokenProvider.isAccessToken(token)) {
             throw new JwtTokenException("Access Token이 아닙니다.");
         }
 
+        // 사용자 ID 추출 (만료된 토큰도 안전하게 처리)
         String userIdStr = jwtTokenProvider.getUserId(token);
-        return Long.parseLong(userIdStr);
+        if (userIdStr == null || userIdStr.isBlank()) {
+            throw new JwtTokenException("토큰에서 사용자 ID를 추출할 수 없습니다.");
+        }
+
+        try {
+            return Long.parseLong(userIdStr);
+        } catch (NumberFormatException e) {
+            throw new JwtTokenException("토큰의 사용자 ID 형식이 잘못되었습니다.");
+        }
     }
 
     /**
@@ -48,14 +66,63 @@ public class JwtUtil {
     }
 
     /**
-     * 토큰에서 userId만 추출 (Request 없이)
+     * 토큰에서 userId만 추출 (Request 없이) - 안전한 버전
      */
     public Long getUserIdFromToken(String token) {
-        if (!jwtTokenProvider.validateToken(token)) {
-            throw new JwtTokenException("유효하지 않은 토큰입니다.");
+        if (token == null || token.trim().isEmpty()) {
+            throw new JwtTokenException("토큰이 없습니다.");
+        }
+
+        // 토큰 상태 검증
+        JwtTokenProvider.TokenValidationResult validationResult =
+                jwtTokenProvider.validateTokenWithDetails(token);
+
+        if (!validationResult.isValid()) {
+            throw new JwtTokenException(validationResult.getMessage());
         }
 
         String userIdStr = jwtTokenProvider.getUserId(token);
-        return Long.parseLong(userIdStr);
+        if (userIdStr == null || userIdStr.isBlank()) {
+            throw new JwtTokenException("토큰에서 사용자 ID를 추출할 수 없습니다.");
+        }
+
+        try {
+            return Long.parseLong(userIdStr);
+        } catch (NumberFormatException e) {
+            throw new JwtTokenException("토큰의 사용자 ID 형식이 잘못되었습니다.");
+        }
+    }
+
+    /**
+     * 만료된 토큰에서도 userId 추출 (특별한 경우용)
+     */
+    public Long getUserIdFromExpiredToken(String token) {
+        if (token == null || token.trim().isEmpty()) {
+            throw new JwtTokenException("토큰이 없습니다.");
+        }
+
+        try {
+            String userIdStr = jwtTokenProvider.getUserId(token); // 만료된 토큰도 처리 가능
+            if (userIdStr == null || userIdStr.isBlank()) {
+                throw new JwtTokenException("토큰에서 사용자 ID를 추출할 수 없습니다.");
+            }
+            return Long.parseLong(userIdStr);
+        } catch (NumberFormatException e) {
+            throw new JwtTokenException("토큰의 사용자 ID 형식이 잘못되었습니다.");
+        }
+    }
+
+    /**
+     * 토큰 유효성 단순 체크 (예외 없이 boolean만 반환)
+     */
+    public boolean isValidToken(String token) {
+        return jwtTokenProvider.validateToken(token);
+    }
+
+    /**
+     * 토큰 만료 여부 체크 (예외 없이 boolean만 반환)
+     */
+    public boolean isTokenExpired(String token) {
+        return jwtTokenProvider.isTokenExpired(token);
     }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- JWT 토큰 만료 시 발생하는 500 에러를 401 에러로 수정
- 만료된 토큰 처리 로직 개선으로 예외 처리 안정화

## 🔧 주요 변경 사항
- JwtTokenProvider
     validateToken(): 예외 던지기 → boolean 반환으로 변경
     getUserId(), isAccessToken(), isRefreshToken(): 만료된 토큰에서도 정보 추출 가능하도록 ExpiredJwtException 처리 개선
     getExpirationDate(): 만료된 토큰의 만료일도 반환 가능하도록 수정
     validateTokenWithDetails(): 토큰 상태 종합 검증 메서드 추가
- JwtUtil
     getUserIdFromToken(): validateTokenWithDetails() 사용해 안전한 토큰 검증으로 변경
     만료/유효하지 않은 토큰 구분하여 적절한 에러 메시지 반환
     getUserIdFromExpiredToken(): 만료된 토큰에서도 userId 추출 가능한 메서드 추가

## 📌 관련 이슈
- closes #135 

## 🚨 체크리스트
 - [x] 빌드 오류 없음
 - [x] 테스트 코드 작성 또는 실행 확인
 - [x]  커밋 메시지 컨벤션을 지킴
 - [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함



