### PR TITLE
[feat] AI 생성 잔소리 메시지와 기존 알림 시스템 연동 (#139)

### DIFF
--- a/src/main/java/com/savit/notification/controller/BusinessNotificationController.java
+++ b/src/main/java/com/savit/notification/controller/BusinessNotificationController.java
@@ -14,10 +14,6 @@ import java.util.Map;
 @RequestMapping("/api/business/notifications")
 @RequiredArgsConstructor
 public class BusinessNotificationController {
-    /**
-     *
-     */
-    
     private final NotificationService notificationService;
     
     /**


### PR DESCRIPTION
## ✅ 작업 내용
- AI 생성 잔소리 메시지와 기존 알림 시스템 연동

## 🔧 주요 변경 사항
- NotificationService 개선 
    - OpenAIInternalService 의존성 주입으로 AI 생성
    - 정규표현식 `\\n`을 사용한 개행 기준 메시지 분리(GPT 응답 본문)
    - 빈 문자열, 10자 미만, 한글 미포함 메시지 자동 제외
    - AI 서비스 장애 시 기존 하드코딩 메시지로 자동 전환

- FallBack 매커니즘 적용 
  - 1단계 
     - AI 서비스 비활성화 시
     - AI 답변이 비어있을 때
  - 2단계
     - 파싱 후 유효한 메시지가 없을 때
  - 3단계
     - 모든 예외 상황 (네트워크, 파싱 오류 등)
   들이 발생 되었을때 기존 하드코딩 메세지로 FallBack
## 📌 관련 이슈
- closes #139 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] AI 메시지 파싱 로직 구현 및 테스트
- [x] 빈 메시지 전송 방지 확인
- [x] 실제 푸시 알림 테스트 완료
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함