### PR TITLE
[feat] 아임포트 가상 결제 시 카드 트랜잭션 저장 기능 추가 (#143)

### DIFF
--- a/src/main/java/com/savit/card/mapper/CardMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardMapper.java
@@ -13,4 +13,5 @@ public interface CardMapper {
     int selectMonthlyUsageAmount(@Param("cardId") Long cardId);
     List<Card> selectCardsByUserId(Long userId);
     boolean existsCardByResCardNoAndUserId(@Param("resCardNo") String resCardNo, @Param("userId") Long userId);
+    Card findFirstCardByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardTransactionMapper.java
@@ -36,4 +36,6 @@ public interface CardTransactionMapper {
     @MapKey("id") // 단일 결과여서 없어도 되는데 빨간 오류줄 없애려고 추가
     Map<String, Object> findTopSpendingByUserAndDate(@Param("userId") Long userId,
                                                      @Param("targetDate") String targetDate);
+
+    void insert(CardTransactionVO transaction);
 }

--- a/src/main/java/com/savit/challenge/dto/IamportPaymentResponseDTO.java
+++ b/src/main/java/com/savit/challenge/dto/IamportPaymentResponseDTO.java
@@ -13,4 +13,6 @@ public class IamportPaymentResponseDTO {
     private long paidAt;
     private Long challengeId;
     private Long userId;
+    private String name;
+    private String pgProvider;
 }

--- a/src/main/resources/mapper/card/CardMapper.xml
+++ b/src/main/resources/mapper/card/CardMapper.xml
@@ -64,4 +64,13 @@
           AND res_cancel_yn = '0'
           AND res_used_date LIKE CONCAT(DATE_FORMAT(NOW(), '%Y%m'), '%')
     </select>
+
+    <select id="findFirstCardByUserId" resultType="com.savit.card.domain.Card">
+        SELECT *
+        FROM Card
+        WHERE user_id = #{userId}
+        ORDER BY id ASC
+            LIMIT 1
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/card/CardTransactionMapper.xml
+++ b/src/main/resources/mapper/card/CardTransactionMapper.xml
@@ -89,4 +89,39 @@
         LIMIT 1
     </select>
 
+    <!-- 예치금 가상 결제 카드 트랜잭션 1건 저장 -->
+    <insert id="insert" parameterType="com.savit.card.domain.CardTransactionVO">
+        INSERT INTO CardTransaction (
+            card_id,
+            res_card_no,
+            res_used_date,
+            res_used_time,
+            res_used_amount,
+            res_cancel_yn,
+            res_cancel_amount,
+            res_total_amount,
+            budget_category_id,
+            category_id,
+            res_member_store_name,
+            res_member_store_type,
+            created_at,
+            updated_at
+        ) VALUES (
+                     #{cardId},
+                     #{resCardNo},
+                     #{resUsedDate},
+                     #{resUsedTime},
+                     #{resUsedAmount},
+                     #{resCancelYn},
+                     #{resCancelAmount},
+                     #{resTotalAmount},
+                     #{budgetCategoryId},
+                     #{categoryId},
+                     #{resMemberStoreName},
+                     #{resMemberStoreType},
+                     NOW(),
+                     NOW()
+                 )
+    </insert>
+
 </mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 아임포트 결제 성공 시 카드 트랜잭션 1건 저장
- 사용자 등록 카드 중 첫 번째 카드 기준으로 연결
- 카드번호, 결제일시, 금액, 가맹점명 등 저장
- 트랜잭션 테이블 XML에 insert 쿼리 및 주석 추가

## 🔧 주요 변경 사항
- `IamportServiceImpl.insertCardTransaction()` 메서드 추가
- `CardTransactionVO`, `CardTransactionMapper.xml` 수정
- `IamportPaymentResponseDTO`에 pgProvider, name 필드 추가

## 📌 관련 이슈
- closes #143 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함