### PR TITLE
[feat] 챌린지 성공실패 상태 관리 및 푸시 알림 시스템 구현 (#142)

### DIFF
--- a/src/main/java/com/savit/challenge/dto/ChallengeFailedParticipantDTO.java
+++ b/src/main/java/com/savit/challenge/dto/ChallengeFailedParticipantDTO.java
@@ -1,0 +1,36 @@
+package com.savit.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챌린지 실패한 참여자 정보
+ * 알림 발송을 위한 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeFailedParticipantDTO {
+    
+    private Long userId;
+    private Long challengeId;
+    private String challengeTitle;
+    private String status; // FAIL
+    private String failReason; // 실패 사유 (선택적)
+    
+    /**
+     * 실패한 참여자 생성
+     */
+    public static ChallengeFailedParticipantDTO createFailed(Long userId, Long challengeId, String challengeTitle, String failReason) {
+        return ChallengeFailedParticipantDTO.builder()
+                .userId(userId)
+                .challengeId(challengeId)
+                .challengeTitle(challengeTitle)
+                .status("FAIL")
+                .failReason(failReason)
+                .build();
+    }
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeParticipationMapper.java
@@ -4,6 +4,7 @@ import com.savit.challenge.dto.ChallengeUpdateRequestDTO;
 import com.savit.challenge.dto.ChallengeSummaryDTO;
 import com.savit.challenge.dto.ParticipantInfo;
 import com.savit.challenge.dto.ParticipationStatusDTO;
+import com.savit.challenge.dto.ChallengeFailedParticipantDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -44,4 +45,7 @@ public interface ChallengeParticipationMapper {
     ParticipationStatusDTO findParticipationById (Long participationId);
   
     List<ChallengeSummaryDTO>  selectChallengeSummary(Long userId);
+    
+    // 새로 실패한 참여자 목록 조회 (알림 발송용)
+    List<ChallengeFailedParticipantDTO> findNewlyFailedParticipants(@Param("targetDate") String targetDate);
 }

--- a/src/main/java/com/savit/challenge/service/ChallengeParticipationService.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeParticipationService.java
@@ -4,6 +4,7 @@ import com.savit.card.domain.CardTransactionVO;
 import com.savit.challenge.dto.ChallengeProgressDTO;
 import com.savit.challenge.dto.ChallengeUpdateRequestDTO;
 import com.savit.challenge.dto.ParticipationStatusDTO;
+import com.savit.challenge.dto.ChallengeFailedParticipantDTO;
 
 import java.util.List;
 
@@ -16,8 +17,10 @@ public interface ChallengeParticipationService {
     void processParticipantProgress(ParticipationStatusDTO participant, CardTransactionVO transaction);
     ChallengeUpdateRequestDTO createUpdateRequest(ChallengeProgressDTO progress);
     void updateParticipationStatus(ChallengeUpdateRequestDTO updateRequest);
-
-
-
-
+    
+    /**
+     * 새로 실패한 참여자 목록 조회 (알림 발송용)
+     * 오늘 실패로 변경된 참여자들만 반환
+     */
+    List<ChallengeFailedParticipantDTO> findNewlyFailedParticipants();
 }

--- a/src/main/java/com/savit/challenge/service/ChallengeParticipationServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeParticipationServiceImpl.java
@@ -5,6 +5,7 @@ import com.savit.card.mapper.CardTransactionMapper;
 import com.savit.challenge.dto.ChallengeProgressDTO;
 import com.savit.challenge.dto.ChallengeUpdateRequestDTO;
 import com.savit.challenge.dto.ParticipationStatusDTO;
+import com.savit.challenge.dto.ChallengeFailedParticipantDTO;
 import com.savit.challenge.mapper.ChallengeParticipationMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -268,6 +271,34 @@ public class ChallengeParticipationServiceImpl implements ChallengeParticipation
         } catch (Exception e) {
             log.error("❌ DB 업데이트 실패 - 참여ID: {}", updateRequest.getParticipationId(), e);
             throw new RuntimeException("DB 업데이트 실패", e);
+        }
+    }
+
+    @Override
+    public List<ChallengeFailedParticipantDTO> findNewlyFailedParticipants() {
+        try {
+            String today = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            log.info("🔍 새로 실패한 챌린지 참여자 조회 시작 - 대상날짜: {}", today);
+            
+            // 오늘 FAIL로 변경된 참여자들 조회 (완료시간이 오늘인 FAIL 상태)
+            List<ChallengeFailedParticipantDTO> failedParticipants = challengeParticipationMapper.findNewlyFailedParticipants(today);
+            
+            log.info("📊 새로 실패한 챌린지 참여자 조회 완료 - {}명", failedParticipants.size());
+            
+            if (!failedParticipants.isEmpty()) {
+                for (int i = 0; i < failedParticipants.size(); i++) {
+                    ChallengeFailedParticipantDTO participant = failedParticipants.get(i);
+                    log.info("❌ 실패참여자[{}] - 사용자: {}, 챌린지: '{}', 상태: {}", 
+                            i+1, participant.getUserId(), participant.getChallengeTitle(), participant.getStatus());
+                }
+            }
+            
+            return failedParticipants;
+            
+        } catch (Exception e) {
+            log.error("❌ 새로 실패한 참여자 조회 실패", e);
+            // 예외 발생 시 빈 리스트 반환하여 알림 프로세스가 중단되지 않도록 함
+            return new ArrayList<>();
         }
     }
 }

--- a/src/main/java/com/savit/notification/controller/BusinessNotificationController.java
+++ b/src/main/java/com/savit/notification/controller/BusinessNotificationController.java
@@ -1,5 +1,7 @@
 package com.savit.notification.controller;
 
+import com.savit.challenge.dto.ChallengeFailedParticipantDTO;
+import com.savit.challenge.service.ChallengeParticipationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import com.savit.notification.service.NotificationService;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -15,6 +18,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class BusinessNotificationController {
     private final NotificationService notificationService;
+    private final ChallengeParticipationService challengeParticipationService;
     
     /**
      * 예산 초과 알림 테스트
@@ -105,19 +109,19 @@ public class BusinessNotificationController {
     }
     
     /**
-     * 챌린지 성공 알림 테스트 - 임시용 생성, 이렇게 안쓸듯..
+     * 새로 실패한 참여자 목록 조회 테스트
      */
-    @PostMapping("/challenge-success/{userId}")
-    public ResponseEntity<Map<String, String>> sendChallengeSuccessTest(
-            @PathVariable Long userId,
-            @RequestParam(defaultValue = "30일 용돈기입장 쓰기") String challengeTitle,
-            @RequestParam(defaultValue = "10,000원") String prize) {
-        
-        Map<String, String> response = new HashMap<>();
+    @GetMapping("/challenge/newly-failed")
+    public ResponseEntity<Map<String, Object>> getNewlyFailedParticipants() {
+        Map<String, Object> response = new HashMap<>();
         try {
-            notificationService.sendChallengeSuccessNotification(userId, challengeTitle, prize);
+            List<ChallengeFailedParticipantDTO> failedParticipants = challengeParticipationService.findNewlyFailedParticipants();
+            
             response.put("status", "success");
-            response.put("message", "챌린지 성공 알림 전송 완료");
+            response.put("count", failedParticipants.size());
+            response.put("participants", failedParticipants);
+            response.put("message", "새로 실패한 참여자 조회 완료");
+            
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             response.put("status", "error");
@@ -127,18 +131,20 @@ public class BusinessNotificationController {
     }
     
     /**
-     * 챌린지 실패 알림 테스트 - 임시용 생성, 이렇게 안쓸듯..
+     * 실제 운영용 챌린지 실패 알림 테스트 (중복 방지 포함)
      */
-    @PostMapping("/challenge-fail/{userId}")
-    public ResponseEntity<Map<String, String>> sendChallengeFailTest(
+    @PostMapping("/challenge-fail-real/{userId}/{challengeId}")
+    public ResponseEntity<Map<String, String>> sendChallengeFailRealTest(
             @PathVariable Long userId,
-            @RequestParam(defaultValue = "30일 용돈기입장 쓰기") String challengeTitle) {
+            @PathVariable Long challengeId,
+            @RequestParam(defaultValue = "테스트 챌린지") String challengeTitle) {
         
         Map<String, String> response = new HashMap<>();
         try {
-            notificationService.sendChallengeFailNotification(userId, challengeTitle);
+            // 실제 운영용 메서드 호출 (중복 방지 로직 포함)
+            notificationService.sendChallengeFailNotification(userId, challengeId, challengeTitle);
             response.put("status", "success");
-            response.put("message", "챌린지 실패 알림 전송 완료");
+            response.put("message", "실제 운영용 챌린지 실패 알림 전송 완료 (중복 방지 포함)");
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             response.put("status", "error");

--- a/src/main/java/com/savit/notification/domain/ChallengeNotificationHistory.java
+++ b/src/main/java/com/savit/notification/domain/ChallengeNotificationHistory.java
@@ -1,0 +1,62 @@
+package com.savit.notification.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 챌린지 알림 발송 이력 관리
+ * 중복 알림 방지를 위한 테이블
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeNotificationHistory {
+    
+    private Long id;
+    private Long userId;
+    private Long challengeId;
+    private String notificationType; // SUCCESS, FAIL 로 지정되게끔
+    private String challengeTitle;
+    private LocalDateTime sentAt;
+    private String targetDate; // YYYYMMDD 형식 (같은 날 중복 방지용)
+    
+    /**
+     * 중복 체크용 키 생성
+     */
+    public String getUniqueKey() {
+        return String.format("%d_%d_%s_%s", userId, challengeId, notificationType, targetDate);
+    }
+    
+    /**
+     * 성공 알림 생성
+     */
+    public static ChallengeNotificationHistory createSuccess(Long userId, Long challengeId, String challengeTitle, String targetDate) {
+        return ChallengeNotificationHistory.builder()
+                .userId(userId)
+                .challengeId(challengeId)
+                .notificationType("SUCCESS")
+                .challengeTitle(challengeTitle)
+                .targetDate(targetDate)
+                .sentAt(LocalDateTime.now())
+                .build();
+    }
+    
+    /**
+     * 실패 알림 생성
+     */
+    public static ChallengeNotificationHistory createFail(Long userId, Long challengeId, String challengeTitle, String targetDate) {
+        return ChallengeNotificationHistory.builder()
+                .userId(userId)
+                .challengeId(challengeId)
+                .notificationType("FAIL")
+                .challengeTitle(challengeTitle)
+                .targetDate(targetDate)
+                .sentAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/savit/notification/mapper/ChallengeNotificationHistoryMapper.java
+++ b/src/main/java/com/savit/notification/mapper/ChallengeNotificationHistoryMapper.java
@@ -1,0 +1,47 @@
+package com.savit.notification.mapper;
+
+import com.savit.notification.domain.ChallengeNotificationHistory;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 챌린지 알림 발송 이력 매퍼
+ */
+@Mapper
+public interface ChallengeNotificationHistoryMapper {
+    
+    /**
+     * 알림 발송 이력 저장
+     */
+    void insertNotificationHistory(ChallengeNotificationHistory history);
+    
+    /**
+     * 중복 알림 체크 - 같은 날 같은 타입 알림 발송 여부 확인
+     */
+    boolean existsByUserChallengeTypeDate(
+            @Param("userId") Long userId,
+            @Param("challengeId") Long challengeId,
+            @Param("notificationType") String notificationType,
+            @Param("targetDate") String targetDate
+    );
+    
+    /**
+     * 사용자별 특정 챌린지 알림 이력 조회
+     */
+    List<ChallengeNotificationHistory> findByUserIdAndChallengeId(
+            @Param("userId") Long userId,
+            @Param("challengeId") Long challengeId
+    );
+    
+    /**
+     * 특정 날짜 알림 발송 이력 조회 (디버깅용)
+     */
+    List<ChallengeNotificationHistory> findByTargetDate(@Param("targetDate") String targetDate);
+    
+    /**
+     * 오래된 알림 이력 정리 (30일 이상 된 데이터)
+     */
+    void deleteOldNotificationHistory(@Param("retentionDays") int retentionDays);
+}

--- a/src/main/resources/mapper/ChallengeNotificationHistoryMapper.xml
+++ b/src/main/resources/mapper/ChallengeNotificationHistoryMapper.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.savit.notification.mapper.ChallengeNotificationHistoryMapper">
+    
+    <!-- 알림 발송 이력 저장 -->
+    <insert id="insertNotificationHistory" parameterType="com.savit.notification.domain.ChallengeNotificationHistory">
+        INSERT INTO ChallengeNotificationHistory (
+            user_id,
+            challenge_id,
+            notification_type,
+            challenge_title,
+            sent_at,
+            target_date
+        ) VALUES (
+            #{userId},
+            #{challengeId},
+            #{notificationType},
+            #{challengeTitle},
+            #{sentAt},
+            #{targetDate}
+        )
+    </insert>
+    
+    <!-- 중복 알림 체크 -->
+    <select id="existsByUserChallengeTypeDate" resultType="boolean">
+        SELECT COUNT(1) > 0
+        FROM ChallengeNotificationHistory
+        WHERE user_id = #{userId}
+          AND challenge_id = #{challengeId}
+          AND notification_type = #{notificationType}
+          AND target_date = #{targetDate}
+    </select>
+    
+    <!-- 사용자별 특정 챌린지 알림 이력 조회 -->
+    <select id="findByUserIdAndChallengeId" resultType="com.savit.notification.domain.ChallengeNotificationHistory">
+        SELECT 
+            id,
+            user_id AS userId,
+            challenge_id AS challengeId,
+            notification_type AS notificationType,
+            challenge_title AS challengeTitle,
+            sent_at AS sentAt,
+            target_date AS targetDate
+        FROM ChallengeNotificationHistory
+        WHERE user_id = #{userId}
+          AND challenge_id = #{challengeId}
+        ORDER BY sent_at DESC
+    </select>
+    
+    <!-- 특정 날짜 알림 발송 이력 조회 -->
+    <select id="findByTargetDate" resultType="com.savit.notification.domain.ChallengeNotificationHistory">
+        SELECT 
+            id,
+            user_id AS userId,
+            challenge_id AS challengeId,
+            notification_type AS notificationType,
+            challenge_title AS challengeTitle,
+            sent_at AS sentAt,
+            target_date AS targetDate
+        FROM ChallengeNotificationHistory
+        WHERE target_date = #{targetDate}
+        ORDER BY sent_at DESC
+    </select>
+    
+    <!-- 오래된 알림 이력 정리 -->
+    <delete id="deleteOldNotificationHistory">
+        DELETE FROM ChallengeNotificationHistory
+        WHERE sent_at &lt; DATE_SUB(NOW(), INTERVAL #{retentionDays} DAY)
+    </delete>
+    
+</mapper>

--- a/src/main/resources/mapper/card/CardTransactionMapper.xml
+++ b/src/main/resources/mapper/card/CardTransactionMapper.xml
@@ -128,7 +128,7 @@
                ct.res_member_store_type,
                ct.created_at,
                ct.updated_at
-        from CardTransaction
+        from CardTransaction ct
         where ct.created_at &gt;= #{lastProcessedTime}
           and ct.res_cancel_yn != 'Y'
   and ct.category_id is not null

--- a/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengePariticipationMapper.xml
@@ -131,5 +131,18 @@
         where cp.user_id = #{userId}  and cp.status IN ('SUCCESS', 'FAIL')
     </select>
 
+    <!-- 새로 실패한 참여자 목록 조회 (알림 발송용) -->
+    <select id="findNewlyFailedParticipants" resultType="com.savit.challenge.dto.ChallengeFailedParticipantDTO">
+        SELECT 
+            cp.user_id AS userId,
+            cp.challenge_id AS challengeId,
+            c.title AS challengeTitle,
+            cp.status AS status
+        FROM ChallengeParticipation cp
+        INNER JOIN Challenge c ON cp.challenge_id = c.id
+        WHERE cp.status = 'FAIL'
+          AND DATE_FORMAT(cp.completed_at, '%Y%m%d') = #{targetDate}
+        ORDER BY cp.completed_at DESC
+    </select>
 
 </mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 챌린지 성공/실패 알림을 테스트용에서 스케줄러 기반 자동화로 변경

## 🔧 주요 변경 사항
- 같은 날 같은 챌린지에 대한 실패여부 중복 알림 완전 차단
- 카드 승인내역 스케줄러 실행 시 자동으로 실패 알림 발송
- 스케줄러 이용 실제 챌린지 참여 데이터 기반 알림

[추가된 파일]
- `ChallengeFailedParticipantDTO.java` : 실패한 챌린지 참여자 정보를 담는 DTO
- `ChallengeNotificationHistory.java` : 챌린지 알림 발송 이력 도메인 
- `ChallengeNotificationHistoryMapper.java, .xml` : 알림 이력 맵퍼 인터페이스 및 xml

[수정한 파일]
- `AsyncCardApprovalService.java` : 카드 승인내역 처리 후 자동 실패 알림 발송 로직 추가
- `ChallengeParticipationService.java` : 실패한 참여자 조회 메서드 인터페이스 추가
- `ChallengeParticipationServiceImpl.java` : 실패한 참여자 조회 로직 구현
- `NotificationService.java` : 중복 방지 로직 포함한 실제 운영용 알림 메서드 구현
- `BusinessNotificationController.java` : 테스트용 API 엔드포인트 추가
- `ChallengeParticipationMapper.java` : 실패한 참여자 조회 메서드 및 쿼리 추가


## 🔄 동작 흐름
- 카드 승인내역 스케줄러 동작 (매 06, 12, 18, 00시)
- 카드 승인내역 DB 업데이트
- 챌린지 참여자 상태 업데이트
- 챌린지 실패자 확인
- 중복 알림 체크(같은날 실패알림 한번 보낸 이력 있으면 안보내게)
- 챌린지 실패 알림 발송 및 이력 저장(이 경우 챌린지 실패 알림 확인용으로 따로 DB 생성했습니다)

## 📌 관련 이슈
- closes #142 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 중복 알림 방지 로직 정상 동작
- [x] 실패 참여자 조회 완료
- [x] 실패 참여자 푸시 알림 발송 확인
- [x] 알림 발송 이력 DB 저장 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함