### PR TITLE
[feat] 카드 이름 수정 API 추가 (#152)

### DIFF
--- a/src/main/java/com/savit/card/controller/CardController.java
+++ b/src/main/java/com/savit/card/controller/CardController.java
@@ -2,6 +2,7 @@ package com.savit.card.controller;
 
 import com.savit.card.dto.CardDetailResponseDTO;
 import com.savit.card.dto.CardRegisterRequestDTO;
+import com.savit.card.dto.CardRenameRequestDTO;
 import com.savit.card.service.CardService;
 import com.savit.security.JwtUtil;
 import com.savit.user.domain.User;
@@ -87,4 +88,23 @@ public class CardController {
         }
     }
 
+    @PatchMapping("/{cardId}/name")
+    public ResponseEntity<?> renameCard(
+            @PathVariable Long cardId,
+            @RequestBody @Valid CardRenameRequestDTO req,
+            HttpServletRequest request
+    ) {
+        Long userId = jwtUtil.getUserIdFromToken(request);
+
+        var updated = cardService.renameCardAndFetch(cardId, userId, req.getCardName());
+        if (updated == null) {
+            return ResponseEntity.status(404).body(Map.of("error", "not found"));
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "cardId", updated.getId(),
+                "cardName", updated.getCardName(),
+                "updatedAt", updated.getUpdatedAt()
+        ));
+    }
 }

--- a/src/main/java/com/savit/card/domain/Card.java
+++ b/src/main/java/com/savit/card/domain/Card.java
@@ -24,5 +24,6 @@ public class Card {
     private String resSleepYn;
     private String resImageLink;
     private LocalDateTime registeredAt;
+    private LocalDateTime updatedAt;
     private Long userId;
 }

--- a/src/main/java/com/savit/card/dto/CardRenameRequestDTO.java
+++ b/src/main/java/com/savit/card/dto/CardRenameRequestDTO.java
@@ -1,0 +1,13 @@
+package com.savit.card.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+public class CardRenameRequestDTO {
+    @NotBlank
+    @Size(max = 50)
+    private String cardName;
+}

--- a/src/main/java/com/savit/card/mapper/CardMapper.java
+++ b/src/main/java/com/savit/card/mapper/CardMapper.java
@@ -14,4 +14,10 @@ public interface CardMapper {
     List<Card> selectCardsByUserId(Long userId);
     boolean existsCardByResCardNoAndUserId(@Param("resCardNo") String resCardNo, @Param("userId") Long userId);
     Card findFirstCardByUserId(@Param("userId") Long userId);
+    int updateCardName(@Param("cardId") Long cardId,
+                       @Param("userId") Long userId,
+                       @Param("cardName") String cardName);
+
+    Card selectCardBasicByIdAndUserId(@Param("cardId") Long cardId,
+                                      @Param("userId") Long userId);
 }

--- a/src/main/java/com/savit/card/service/CardService.java
+++ b/src/main/java/com/savit/card/service/CardService.java
@@ -12,6 +12,7 @@ import io.codef.api.EasyCodefTokenMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -159,4 +160,13 @@ public class CardService {
         }).toList();
     }
 
+    @Transactional
+    public Card renameCardAndFetch(Long cardId, Long userId, String newName) {
+        if (newName == null || newName.isBlank()) return null;
+
+        int updated = cardMapper.updateCardName(cardId, userId, newName);
+        if (updated != 1) return null;
+
+        return cardMapper.selectCardBasicByIdAndUserId(cardId, userId);
+    }
 }

--- a/src/main/resources/mapper/card/CardMapper.xml
+++ b/src/main/resources/mapper/card/CardMapper.xml
@@ -73,4 +73,23 @@
             LIMIT 1
     </select>
 
+    <update id="updateCardName">
+        UPDATE Card
+        SET card_name = #{cardName},
+            updated_at = NOW()
+        WHERE id = #{cardId}
+          AND user_id = #{userId}
+    </update>
+
+    <select id="selectCardBasicByIdAndUserId" resultType="com.savit.card.domain.Card">
+        SELECT
+            id,
+            user_id,
+            card_name,
+            updated_at
+        FROM Card
+        WHERE id = #{cardId}
+          AND user_id = #{userId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 카드 이름 수정 API 구현
- 수정 성공 시 200 OK + 변경된 카드 정보(cardId, cardName, updatedAt) 반환
- 본인 소유 카드만 수정 가능하도록 user_id 조건 검증 추가
- Card 엔티티에 updatedAt 필드 추가

## 🔧 주요 변경 사항
- `CardController.java`
  - `PATCH /api/cards/{cardId}/name` 엔드포인트 추가
  - 응답 포맷 변경 (204 → 200 OK + 변경된 카드 정보)
- `CardService.java`
  - `renameCardAndFetch` 메서드 구현
- `CardMapper.java` / `CardMapper.xml`
  - `updateCardName` SQL 추가 (`updated_at = NOW()`)
  - `selectCardBasicByIdAndUserId` SQL 추가 (변경 후 최신 데이터 조회)
- `Card.java`
  - `updatedAt` 필드 추가 (DB `updated_at` 매핑)
- DB 스키마 변경
  - `Card` 테이블에 `updated_at` 컬럼(DATETIME NULL) 추가

## 📌 관련 이슈
- closes #152

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함