### PR TITLE
[fix] 만료된 access token 발급시 refreshToken 발급 (#161)

### DIFF
--- a/src/main/java/com/savit/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/savit/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.savit.security;
 
 import com.savit.common.exception.JwtTokenException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.*;
@@ -11,6 +12,7 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationFilter implements Filter {
 
     private final JwtUtil jwtUtil;
@@ -23,26 +25,56 @@ public class JwtAuthenticationFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
         if ("OPTIONS".equals(httpRequest.getMethod())) {
+            httpResponse.setHeader("Access-Control-Allow-Origin", "*");
+            httpResponse.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, Refresh-Token");
+            httpResponse.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
             chain.doFilter(request, response);
             return;
         }
-
-
         try {
+            // 기존 메서드 사용 - 내부적으로 자동 갱신 처리됨
             Long userId = jwtUtil.getUserIdFromToken(httpRequest);
+
+            // userId를 request attribute에 설정
             httpRequest.setAttribute("userId", userId.toString());
+
+            // 토큰이 갱신되었는지 확인하여 응답 헤더에 포함
+            String newAccessToken = (String) httpRequest.getAttribute("newAccessToken");
+            Boolean tokenRefreshed = (Boolean) httpRequest.getAttribute("tokenRefreshed");
+
+            if (tokenRefreshed != null && tokenRefreshed && newAccessToken != null) {
+                httpResponse.setHeader("New-Access-Token", newAccessToken);
+                httpResponse.setHeader("Token-Refreshed", "true");
+                log.info("토큰 자동 갱신됨 - userId: {}", userId);
+            }
+
         } catch (JwtTokenException e) {
-            httpResponse.setStatus(401);
-            httpResponse.setCharacterEncoding("UTF-8");
-            httpResponse.setContentType("application/json;charset=UTF-8");
-
-            httpResponse.setHeader("Access-Control-Allow-Origin", "*");
-            httpResponse.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-            httpResponse.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-
-            httpResponse.getWriter().write("\"" + e.getMessage() + "\"");
+            log.error("JWT 인증 실패: {}", e.getMessage());
+            sendUnauthorizedResponse(httpResponse, e.getMessage());
+            return;
+        } catch (Exception e) {
+            // 예상하지 못한 모든 예외를 401로 처리 (절대 500 에러 방지)
+            log.error("JWT 필터에서 예상치 못한 오류 발생", e);
+            sendUnauthorizedResponse(httpResponse, "인증 처리 중 오류가 발생했습니다.");
             return;
         }
-        chain.doFilter(request,response);
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * 401 에러 응답 전송
+     */
+    private void sendUnauthorizedResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(401);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json;charset=UTF-8");
+
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, Refresh-Token");
+        response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        response.setHeader("Access-Control-Expose-Headers", "New-Access-Token, Token-Refreshed");
+
+        response.getWriter().write("\"" + message + "\"");
     }
 }

--- a/src/main/java/com/savit/security/JwtUtil.java
+++ b/src/main/java/com/savit/security/JwtUtil.java
@@ -1,79 +1,187 @@
 package com.savit.security;
 
 import com.savit.common.exception.JwtTokenException;
+import com.savit.user.domain.User;
+import com.savit.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtUtil {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
 
     /**
-     * HttpServletRequest에서 userId 추출 (안전한 버전)
+     * HttpServletRequest에서 userId 추출 (자동 토큰 갱신 포함)
      */
-    public Long getUserIdFromToken(HttpServletRequest request) {
-        String token = extractTokenFromRequest(request);
-
-        if (token == null) {
-            throw new JwtTokenException("토큰이 없습니다.");
-        }
-
-        // 토큰 상태 종합 검증
-        JwtTokenProvider.TokenValidationResult validationResult =
-                jwtTokenProvider.validateTokenWithDetails(token);
-
-        if (!validationResult.isValid()) {
-            if (validationResult.isExpired()) {
-                throw new JwtTokenException("토큰이 만료되었습니다.");
-            } else {
-                throw new JwtTokenException("유효하지 않은 토큰입니다.");
-            }
-        }
-
-        // Access Token 확인 (만료된 토큰도 안전하게 처리)
-        if (!jwtTokenProvider.isAccessToken(token)) {
-            throw new JwtTokenException("Access Token이 아닙니다.");
-        }
-
-        // 사용자 ID 추출 (만료된 토큰도 안전하게 처리)
-        String userIdStr = jwtTokenProvider.getUserId(token);
-        if (userIdStr == null || userIdStr.isBlank()) {
-            throw new JwtTokenException("토큰에서 사용자 ID를 추출할 수 없습니다.");
-        }
-
+    public TokenResult getUserIdFromTokenWithAutoRefresh(HttpServletRequest request) {
         try {
-            return Long.parseLong(userIdStr);
-        } catch (NumberFormatException e) {
-            throw new JwtTokenException("토큰의 사용자 ID 형식이 잘못되었습니다.");
+            String accessToken = extractAccessTokenFromRequest(request);
+            String refreshToken = extractRefreshTokenFromRequest(request);
+
+            if (accessToken == null) {
+                throw new JwtTokenException("Access Token이 없습니다.");
+            }
+
+            // 1. Access Token 검증
+            JwtTokenProvider.TokenValidationResult validationResult =
+                    jwtTokenProvider.validateTokenWithDetails(accessToken);
+// 2. Access Token이 유효한 경우
+            if (validationResult.isValid()) {
+                // Access Token 타입 확인
+                if (!jwtTokenProvider.isAccessToken(accessToken)) {
+                    throw new JwtTokenException("Access Token이 아닙니다.");
+                }
+
+                // 사용자 ID 추출
+                String userIdStr = jwtTokenProvider.getUserId(accessToken);
+                if (userIdStr == null || userIdStr.isBlank()) {
+                    throw new JwtTokenException("토큰에서 사용자 ID를 추출할 수 없습니다.");
+                }
+
+                try {
+                    Long userId = Long.parseLong(userIdStr);
+                    return TokenResult.builder()
+                            .userId(userId)
+                            .newAccessToken(null) // 갱신되지 않음
+                            .tokenRefreshed(false)
+                            .build();
+                } catch (NumberFormatException e) {
+                    throw new JwtTokenException("토큰의 사용자 ID 형식이 잘못되었습니다.");
+                }
+            }
+
+            // 3. Access Token이 만료된 경우 - 자동 갱신 시도
+            if (validationResult.isExpired()) {
+                log.info("Access Token 만료 감지, 자동 갱신 시도");
+
+                if (refreshToken == null) {
+                    throw new JwtTokenException("Refresh Token이 없어 토큰 갱신이 불가능합니다.");
+                }
+
+                try {
+                    // 만료된 Access Token에서 userId 추출
+                    String userIdStr = jwtTokenProvider.getUserId(accessToken);
+                    Long userId = Long.parseLong(userIdStr);
+
+                    // Refresh Token으로 새 Access Token 발급
+                    String newAccessToken = refreshAccessToken(userId, refreshToken);
+
+                    log.info("토큰 자동 갱신 성공 - userId: {}", userId);
+
+                    return TokenResult.builder()
+                            .userId(userId)
+                            .newAccessToken(newAccessToken)
+                            .tokenRefreshed(true)
+                            .build();
+
+                } catch (Exception e) {
+                    log.error("토큰 자동 갱신 실패", e);
+                    throw new JwtTokenException("토큰 갱신에 실패했습니다: " + e.getMessage());
+                }
+            }
+
+            // 4. Access Token이 유효하지 않은 경우 (변조 등)
+            throw new JwtTokenException(validationResult.getMessage());
+
+        } catch (JwtTokenException e) {
+            // JwtTokenException은 그대로 던짐
+            throw e;
+        } catch (Exception e) {
+            // 예상하지 못한 모든 예외를 JwtTokenException으로 변환 (500 에러 방지)
+            log.error("토큰 처리 중 예상치 못한 오류 발생", e);
+            throw new JwtTokenException("토큰 처리 중 오류가 발생했습니다.");
         }
     }
 
     /**
-     * Request Header에서 토큰 추출
+     * Refresh Token으로 새 Access Token 발급
      */
-    private String extractTokenFromRequest(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
+    private String refreshAccessToken(Long userId, String refreshToken) {
+        try {
+            // 1. Refresh Token 유효성 검증
+            JwtTokenProvider.TokenValidationResult refreshValidation =
+                    jwtTokenProvider.validateTokenWithDetails(refreshToken);
 
+            if (!refreshValidation.isValid()) {
+                throw new JwtTokenException("유효하지 않은 Refresh Token입니다: " + refreshValidation.getMessage());
+            }
+
+            // 2. Refresh Token 타입 확인
+            if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+                throw new JwtTokenException("Refresh Token이 아닙니다.");
+            }
+
+            // 3. 사용자 조회 및 DB의 Refresh Token과 비교
+            User user = userService.findById(userId);
+            if (user == null) {
+                throw new JwtTokenException("존재하지 않는 사용자입니다.");
+            }
+
+            if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+                throw new JwtTokenException("저장된 Refresh Token과 일치하지 않습니다.");
+            }
+
+            // 4. 새 Access Token 생성
+            String newAccessToken = jwtTokenProvider.createAccessToken(userId.toString());
+
+            log.info("새 Access Token 발급 완료 - userId: {}", userId);
+            return newAccessToken;
+
+        } catch (JwtTokenException e) {
+            // JwtTokenException은 그대로 던짐
+            throw e;
+        } catch (Exception e) {
+            // 예상하지 못한 모든 예외를 JwtTokenException으로 변환 (500 에러 방지)
+            log.error("토큰 갱신 중 예상치 못한 오류 발생", e);
+            throw new JwtTokenException("토큰 갱신 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * Request Header에서 Access Token 추출
+     */
+    private String extractAccessTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
-
         return null;
     }
 
     /**
-     * 토큰에서 userId만 추출 (Request 없이) - 안전한 버전
+     * Request Header에서 Refresh Token 추출
      */
+    private String extractRefreshTokenFromRequest(HttpServletRequest request) {
+        return request.getHeader("Refresh-Token");
+    }
+
+    /**
+     * 기존 메서드 - 자동 갱신 기능 포함 (기존 코드 호환성 완벽 유지)
+     */
+    public Long getUserIdFromToken(HttpServletRequest request) {
+        TokenResult result = getUserIdFromTokenWithAutoRefresh(request);
+
+        // 토큰이 갱신된 경우 응답에 포함시키기 위해 request attribute에 저장
+        if (result.isTokenRefreshed()) {
+            request.setAttribute("newAccessToken", result.getNewAccessToken());
+            request.setAttribute("tokenRefreshed", true);
+        }
+
+        return result.getUserId();
+    }
+
     public Long getUserIdFromToken(String token) {
         if (token == null || token.trim().isEmpty()) {
             throw new JwtTokenException("토큰이 없습니다.");
         }
 
-        // 토큰 상태 검증
         JwtTokenProvider.TokenValidationResult validationResult =
                 jwtTokenProvider.validateTokenWithDetails(token);
 
@@ -93,16 +201,13 @@ public class JwtUtil {
         }
     }
 
-    /**
-     * 만료된 토큰에서도 userId 추출 (특별한 경우용)
-     */
     public Long getUserIdFromExpiredToken(String token) {
         if (token == null || token.trim().isEmpty()) {
             throw new JwtTokenException("토큰이 없습니다.");
         }
 
         try {
-            String userIdStr = jwtTokenProvider.getUserId(token); // 만료된 토큰도 처리 가능
+            String userIdStr = jwtTokenProvider.getUserId(token);
             if (userIdStr == null || userIdStr.isBlank()) {
                 throw new JwtTokenException("토큰에서 사용자 ID를 추출할 수 없습니다.");
             }
@@ -112,17 +217,22 @@ public class JwtUtil {
         }
     }
 
-    /**
-     * 토큰 유효성 단순 체크 (예외 없이 boolean만 반환)
-     */
     public boolean isValidToken(String token) {
         return jwtTokenProvider.validateToken(token);
     }
 
-    /**
-     * 토큰 만료 여부 체크 (예외 없이 boolean만 반환)
-     */
     public boolean isTokenExpired(String token) {
         return jwtTokenProvider.isTokenExpired(token);
+    }
+
+    /**
+     * 토큰 처리 결과를 담는 클래스
+     */
+    @lombok.Builder
+    @lombok.Getter
+    public static class TokenResult {
+        private Long userId;
+        private String newAccessToken;  // 갱신된 새 Access Token (갱신되지 않았으면 null)
+        private boolean tokenRefreshed; // 토큰이 갱신되었는지 여부
     }
 }

--- a/src/main/java/com/savit/user/controller/AuthController.java
+++ b/src/main/java/com/savit/user/controller/AuthController.java
@@ -74,6 +74,7 @@ public class AuthController {
 
             log.info("======== 카카오 로그인 처리 완료 ==========");
             log.info("accessToken = {}", loginResponse.getAccessToken());
+            log.info("refreshToken = {}", loginResponse.getRefreshToken());
 
             // 성공 시 프론트엔드로 리다이렉트 (토큰 포함)
             String redirectUrl = "http://localhost:8080/auth/login/callback" +
@@ -96,36 +97,6 @@ public class AuthController {
         }
     }
 
-
-    /**
-     * Refresh Token으로 Access Token 갱신
-     */
-    @PostMapping("/refresh")
-    @ResponseBody
-    public ResponseEntity<?> refreshToken(@RequestBody RefreshTokenRequest request) {
-        try {
-            log.info("토큰 갱신 요청");
-
-            if (request.getRefreshToken() == null || request.getRefreshToken().trim().isEmpty()) {
-                return ResponseEntity.badRequest().body("Refresh Token이 필요합니다.");
-            }
-
-            // Refresh Token으로 새 Access Token 발급
-            LoginResponseDTO response = authService.refreshAccessToken(request.getRefreshToken());
-
-            log.info("토큰 갱신 성공");
-            return ResponseEntity.ok(response);
-
-        } catch (IllegalArgumentException e) {
-            log.error("토큰 갱신 실패 - 잘못된 요청: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body("유효하지 않은 Refresh Token입니다.");
-        } catch (Exception e) {
-            log.error("토큰 갱신 실패:", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("토큰 갱신 중 오류가 발생했습니다.");
-        }
-    }
 
     /**
      * 로그아웃 (토큰 무효화)

--- a/src/main/java/com/savit/user/service/AuthService.java
+++ b/src/main/java/com/savit/user/service/AuthService.java
@@ -11,10 +11,5 @@ public interface AuthService {
      */
     LoginResponseDTO kakaoLogin(String code);
 
-    /**
-     * Refresh Token으로 새로운 Access Token 발급
-     * @param refreshToken 갱신용 토큰
-     * @return 새로운 토큰 정보
-     */
-    LoginResponseDTO refreshAccessToken(String refreshToken);
+
 }

--- a/src/main/java/com/savit/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/savit/user/service/AuthServiceImpl.java
@@ -101,56 +101,5 @@ public class AuthServiceImpl implements AuthService {
         }
     }
 
-    /**
-     * Refresh Token으로 새로운 Access Token 발급
-     */
-    public LoginResponseDTO refreshAccessToken(String refreshToken) {
-        try {
-            log.info("Refresh Token으로 Access Token 갱신 시작");
 
-            // 1. Refresh Token 유효성 검증
-            if (!jwtTokenProvider.validateToken(refreshToken)) {
-                throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
-            }
-
-            // 2. Refresh Token인지 확인
-            if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
-                throw new IllegalArgumentException("Refresh Token이 아닙니다.");
-            }
-
-            // 3. Refresh Token에서 userId 추출
-            Long userId = Long.parseLong(jwtTokenProvider.getUserId(refreshToken));
-            User user = userService.findById(userId);  // userId 기반 조회
-
-            if (user == null) {
-                throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
-            }
-
-            // 4. 새로운 Access Token 생성 (userId 기반)
-            String newAccessToken = jwtTokenProvider.createAccessToken(String.valueOf(userId));
-
-            log.info("Access Token 갱신 완료 - userId: {}", userId);
-
-            return LoginResponseDTO.builder()
-                    .accessToken(newAccessToken)
-                    .refreshToken(refreshToken)
-                    .user(User.builder()
-                            .id(user.getId())
-                            .email(user.getEmail())
-                            .nickname(user.getNickname())
-                            .profileImage(user.getProfileImage())
-                            .kakaoUserId(user.getKakaoUserId())
-                            .createdAt(user.getCreatedAt())
-                            .updatedAt(user.getUpdatedAt())
-                            .build())
-                    .accessTokenExpiresIn(3600L)
-                    .success(true)
-                    .message("토큰 갱신 성공")
-                    .build();
-
-        } catch (Exception e) {
-            log.error("토큰 갱신 실패:", e);
-            throw new RuntimeException("토큰 갱신 실패", e);
-        }
-    }
 }


### PR DESCRIPTION
## ✅ 작업 내용

- JWT Access Token 자동 갱신 시스템 구현

## 🔧 주요 변경 사항

- JwtUtil: getUserIdFromTokenWithAutoRefresh() 메서드 추가 - Access Token 만료 시 Refresh Token으로 자동 갱신
- JwtAuthenticationFilter: OPTIONS 요청 CORS 헤더 추가, 토큰 자동 갱신 응답 헤더 처리
- TokenResult DTO: 토큰 갱신 결과를 담는 DTO 클래스 추가
- AuthController: 중복된 /refresh 엔드포인트 제거
- 헤더 설정: Refresh-Token 헤더 허용 설정 추가

## 📌 관련 이슈
- closes #161 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함