### PR TITLE
[feat] 챌린지 자동 정산 스케줄러 구현 (#163)

### DIFF
--- a/src/main/java/com/savit/challenge/domain/ChallengeParticipationVO.java
+++ b/src/main/java/com/savit/challenge/domain/ChallengeParticipationVO.java
@@ -1,0 +1,20 @@
+package com.savit.challenge.domain;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Data
+public class ChallengeParticipationVO {
+    private Long id;
+    private String status;
+    private Long challengeId;
+    private Long userId;
+    private Date createdAt;
+    private Date completedAt;
+    private Date updatedAt;
+    private Long challengeCount;
+    private BigDecimal challengeAmount;
+    private Long myFee;
+    private Long prize;
+}

--- a/src/main/java/com/savit/challenge/mapper/SettlementMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/SettlementMapper.java
@@ -1,0 +1,28 @@
+package com.savit.challenge.mapper;
+
+import com.savit.challenge.domain.ChallengeParticipationVO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface SettlementMapper {
+
+    List<ChallengeParticipationVO> selectForUpdate(@Param("challengeId") Long challengeId);
+
+    boolean existsAnyPrizeWritten(@Param("challengeId") Long challengeId);
+
+    int updateWinnerPrize(@Param("challengeId") Long challengeId,
+                          @Param("userId") Long userId,
+                          @Param("payout") long payout);
+
+    int updateLoserPrize(@Param("challengeId") Long challengeId,
+                         @Param("userId") Long userId,
+                         @Param("amount") long amount);
+
+    int upsertPoint(@Param("userId") Long userId,
+                    @Param("delta") long delta);
+
+    Long findUserIdByEmail(@Param("email") String email);
+}

--- a/src/main/java/com/savit/challenge/service/SettlementService.java
+++ b/src/main/java/com/savit/challenge/service/SettlementService.java
@@ -1,0 +1,5 @@
+package com.savit.challenge.service;
+
+public interface SettlementService {
+    void settle(Long challengeId);
+}

--- a/src/main/java/com/savit/challenge/service/SettlementServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/SettlementServiceImpl.java
@@ -1,0 +1,97 @@
+package com.savit.challenge.service;
+
+import com.savit.challenge.domain.ChallengeParticipationVO;
+import com.savit.challenge.mapper.SettlementMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SettlementServiceImpl implements SettlementService {
+
+    private final SettlementMapper mapper;
+    private static final String OPS_EMAIL = "ops@savit.local";
+
+    @Override
+    @Transactional
+    public void settle(Long challengeId) {
+        log.info("[정산] 시작 - challengeId={}", challengeId);
+
+        // 멱등 가드: 이미 prize가 기록된 적 있으면 스킵
+        if (mapper.existsAnyPrizeWritten(challengeId)) {
+            log.warn("[정산] 이미 정산 완료되어 스킵 - challengeId={}", challengeId);
+            return;
+        }
+
+        // 정산 대상 잠금 (FOR UPDATE)
+        List<ChallengeParticipationVO> parts = mapper.selectForUpdate(challengeId);
+        if (parts == null || parts.isEmpty()) {
+            log.info("[정산] 참가자가 없어 종료 - challengeId={}", challengeId);
+            return;
+        }
+
+        // 분류: 성공자 / 실패자
+        var winners = parts.stream().filter(p -> "SUCCESS".equals(p.getStatus())).toList();
+        var losers  = parts.stream().filter(p -> "FAIL".equals(p.getStatus())).toList();
+
+        // 실패자: 수수료(1%) 및 풀 계산 (원 단위 정수, 소수점 버림)
+        long feeSum = 0L; // 회사 수수료 합계
+        long pool   = 0L; // 성공자에게 배분할 풀(= 실패자 예치금 - 수수료)
+        for (var l : losers) {
+            long d   = nz(l.getMyFee()); // 예치금
+            long fee = fee1pct(d);
+            feeSum += fee;
+            pool   += (d - fee);
+        }
+
+        // 성공자 배분: 풀을 성공자 예치금 비율대로 분배 (정수 나눗셈 → 버림)
+        long wSum = winners.stream().mapToLong(w -> nz(w.getMyFee())).sum();
+        long paid = 0L;
+        for (var w : winners) {
+            long s = nz(w.getMyFee());
+            long payout = (wSum == 0L) ? 0L : (pool * s) / wSum;
+            if (payout != 0L) {
+                mapper.updateWinnerPrize(challengeId, w.getUserId(), payout);
+                mapper.upsertPoint(w.getUserId(), payout);
+                paid += payout;
+            }
+        }
+
+        // 실패자 회수: 예치금만큼 prize에 음수 반영 및 포인트 차감
+        for (var l : losers) {
+            long d = nz(l.getMyFee());
+            if (d != 0L) {
+                mapper.updateLoserPrize(challengeId, l.getUserId(), d);
+                mapper.upsertPoint(l.getUserId(), -d);
+            }
+        }
+
+        // 운영자 적립: 수수료 합 + 분배 후 남는 잔액(버림으로 생김)
+        long remainder = pool - paid;
+        Long opsUserId = mapper.findUserIdByEmail(OPS_EMAIL);
+        if (opsUserId == null) {
+            throw new IllegalStateException("운영 계정을 찾을 수 없습니다: " + OPS_EMAIL);
+        }
+
+        long opsGain = feeSum + remainder;
+        if (opsGain != 0L) {
+            mapper.upsertPoint(opsUserId, opsGain);
+        }
+
+        log.info(
+                "[정산] 완료 - cid={}, 성공자 수={}, 실패자 수={}, 수수료합={}, 배분풀={}, 지급합계={}, 잔여금={}, 운영자적립={}",
+                challengeId, winners.size(), losers.size(), feeSum, pool, paid, remainder, opsGain
+        );
+    }
+
+    private long nz(Long v) { return (v == null) ? 0L : v; }
+    private long fee1pct(long myFee) { return myFee / 100; }
+}
+

--- a/src/main/java/com/savit/config/RootConfig.java
+++ b/src/main/java/com/savit/config/RootConfig.java
@@ -14,10 +14,14 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import javax.sql.DataSource;
 
 @Configuration
+@EnableScheduling
+@EnableTransactionManagement
 @PropertySource("classpath:/application.properties")
 @MapperScan(basePackages = "com.savit.**.mapper")
 @ComponentScan(basePackages = "com.savit")

--- a/src/main/java/com/savit/config/SchedulerConfig.java
+++ b/src/main/java/com/savit/config/SchedulerConfig.java
@@ -51,4 +51,15 @@ public class SchedulerConfig {
         
         return executor;
     }
+
+    @Bean
+    public org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler taskScheduler() {
+        var ts = new org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler();
+        ts.setPoolSize(4);
+        ts.setThreadNamePrefix("sched-");
+        ts.setWaitForTasksToCompleteOnShutdown(true);
+        ts.setAwaitTerminationSeconds(30);
+        return ts;
+    }
+
 }

--- a/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
+++ b/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
@@ -39,6 +39,7 @@ public class SchedulerTestController {
     private final ChallengeDropoutScheduler challengeDropoutScheduler;
     private final DailyTopSpendingScheduler dailyTopSpendingScheduler;
     private final ChallengeStartNotificationScheduler challengeStartNotificationScheduler;
+    private final ChallengeSettlementScheduler challengeSettlementScheduler;
 
 
     /**
@@ -353,5 +354,28 @@ public class SchedulerTestController {
         }
     }
 
+    @PostMapping("/challenge-settlement")
+    public ResponseEntity<Map<String, Object>> testChallengeSettlement() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== 챌린지 정산 스케줄러 수동 테스트 시작 ===");
+
+            // settlement 스케줄러 직접 실행
+            challengeSettlementScheduler.runSettlementOnly();
+
+            response.put("status", "success");
+            response.put("message", "챌린지 정산 스케줄러 실행 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("챌린지 정산 스케줄러 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
 
 }

--- a/src/main/java/com/savit/scheduler/job/ChallengeSettlementScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/ChallengeSettlementScheduler.java
@@ -1,0 +1,47 @@
+package com.savit.scheduler.job;
+
+import com.savit.challenge.domain.ChallengeVO;
+import com.savit.challenge.service.ChallengeCompletionService;
+import com.savit.challenge.service.SettlementService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeSettlementScheduler {
+
+    private final ChallengeCompletionService completionService;
+    private final SettlementService settlementService;
+
+    // 성공자 처리(00:00 KST) 이후 10분 뒤 정산만 수행
+    @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")
+    public void runSettlementOnly() {
+        LocalDate todayKst = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        log.info("===== [정산] 시작 — 기준일(KST): {} / 실행시각: 00:10", todayKst);
+
+        List<ChallengeVO> ending = completionService.findChallengesEndingToday();
+        if (ending == null || ending.isEmpty()) {
+            log.info("===== [정산] 오늘 종료되는 챌린지가 없습니다. 작업을 종료합니다.");
+            return;
+        }
+
+        int settled = 0;
+        for (ChallengeVO ch : ending) {
+            try {
+                settlementService.settle(ch.getId());
+                settled++;
+            } catch (Exception e) {
+                log.error("===== [정산] 챌린지 정산 실패 — challengeId={}", ch.getId(), e);
+                // 다음 챌린지 계속 진행
+            }
+        }
+        log.info("===== [정산] 완료 — 정산된 챌린지 수: {}", settled);
+    }
+}

--- a/src/main/resources/mapper/challenge/SettlementMapper.xml
+++ b/src/main/resources/mapper/challenge/SettlementMapper.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.savit.challenge.mapper.SettlementMapper">
+
+    <!-- 정산 대상 잠금 -->
+    <select id="selectForUpdate" resultType="com.savit.challenge.domain.ChallengeParticipationVO">
+        SELECT id,
+               challenge_id AS challengeId,
+               user_id      AS userId,
+               status,
+               challenge_amount AS challengeAmount,
+               my_fee       AS myFee,
+               prize
+        FROM ChallengeParticipation
+        WHERE challenge_id = #{challengeId}
+            FOR UPDATE
+    </select>
+
+    <!-- 멱등 가드: 이미 prize가 기록된 적 있는지 확인 -->
+    <select id="existsAnyPrizeWritten" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM ChallengeParticipation
+        WHERE challenge_id = #{challengeId}
+        AND prize IS NOT NULL
+        AND prize &lt;&gt; 0
+    </select>
+
+    <!-- 성공자 상금 누적 -->
+    <update id="updateWinnerPrize">
+        UPDATE ChallengeParticipation
+        SET prize = COALESCE(prize,0) + #{payout},
+            updated_at = NOW()
+        WHERE challenge_id = #{challengeId}
+          AND user_id = #{userId}
+    </update>
+
+    <!-- 실패자 예치금 회수(음수 기록) -->
+    <update id="updateLoserPrize">
+        UPDATE ChallengeParticipation
+        SET prize = COALESCE(prize,0) - #{amount},
+            updated_at = NOW()
+        WHERE challenge_id = #{challengeId}
+          AND user_id = #{userId}
+    </update>
+
+    <!-- 포인트 증감(UPSERT) -->
+    <insert id="upsertPoint">
+        INSERT INTO Point (user_id, amount, created_at, updated_at)
+        VALUES (#{userId}, #{delta}, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE
+                                 amount = amount + VALUES(amount),
+                                 updated_at = NOW()
+    </insert>
+
+    <!-- 운영 계정 -->
+    <select id="findUserIdByEmail" resultType="long">
+        SELECT id FROM `User` WHERE email = #{email} LIMIT 1
+    </select>
+
+</mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 챌린지 종료 시 성공/실패에 따른 **포인트 정산 기능** 추가
- 실패자 예치금 회수(`-my_fee`), 성공자 **비율 배분**, 수수료/잔여금 **운영자 포인트 귀속**
- **정산 스케줄러**(`ChallengeSettlementScheduler`): KST 00:10에 오늘 종료 챌린지 대상 정산 실행
- (로컬 전용) **수동 테스트 엔드포인트** 추가: `/api/test/scheduler/challenge-settlement`

## 🔧 주요 변경 사항
- `SettlementService` / `SettlementServiceImpl` 구현
- `SettlementMapper` / `SettlementMapper.xml` 추가
- `ChallengeParticipationVO` 추가
- `ChallengeSettlementScheduler` 추가
- `RootConfig`: `@EnableScheduling`, `@EnableTransactionManagement` 추가
- (테스트) `SchedulerTestController`: 정산 스케줄러 수동 실행 API 추가

## 📌 관련 이슈
- closes #163 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함