### PR TITLE
[feat] 하루 마무리 알림 하드코딩된거 LLM 활용 메세지로 전환 (#147)

### DIFF
--- a/src/main/java/com/savit/notification/service/NotificationService.java
+++ b/src/main/java/com/savit/notification/service/NotificationService.java
@@ -207,6 +207,61 @@ public class NotificationService {
     }
     
     /**
+     * 하루 마무리 알림
+     */
+    public void sendDailyWrapUpNotification(Long userId) {
+        String wrapUpMessage = getDailyWrapUpMessage();
+        String title = "🌙 하루 마무리";
+        sendNotificationToUser(userId, title, wrapUpMessage);
+        log.info("하루 마무리 알림 전송 완료 - 사용자: {}, 메시지: {}", userId, wrapUpMessage);
+    }
+
+    /**
+     * OpenAI로 생성된 하루 마무리 메시지
+     * 또는 디폴트 메시지 전송
+     * @return aiMessage or defaultMessage
+     */
+    private String getDailyWrapUpMessage() {
+        try {
+            if(openAIInternalService.isServiceEnabled() && !openAIInternalService.getDailyWrapUpAnswers().isEmpty()) {
+                String aiResponse = openAIInternalService.getDailyWrapUpAnswers().get(0);
+                String[] aiMessages = aiResponse.split("\\n");  // 정규표현식에서 개행 문자 찾는 용도로 \\n 사용함
+                
+                // 유효한 메시지만 필터링
+                List<String> validMessages = new ArrayList<>();
+                for (String message : aiMessages) {
+                    String trimmed = message.trim();
+                    // 빈 문자열이 아니고, 10자 이상이고, 한글이 포함된 메시지만 선택
+                    if (!trimmed.isEmpty() && trimmed.length() > 10 && trimmed.matches(".*[가-힣].*")) {
+                        validMessages.add(trimmed);
+                    }
+                }
+                
+                if (!validMessages.isEmpty()) {
+                    String selectedMessage = validMessages.get((int) (Math.random() * validMessages.size()));
+                    log.debug("선택된 AI 하루 마무리 메시지: {}", selectedMessage);
+                    return selectedMessage;
+                } else {
+                    log.warn("유효한 AI 하루 마무리 메시지가 없음, 기본 메시지 사용");
+                }
+            }
+        } catch (Exception e) {
+            log.error("OpenAI 하루 마무리 메시지 사용 실패, 기본 메시지를 사용합니다", e);
+        }
+        
+        // 기본 하루 마무리 메시지
+        String[] defaultWrapUpMessages = {
+            "오늘 하루 신용카드는 덜 썼죠? 내일도 화이팅! 📝✨",
+            "내일을 위해 오늘의 지출을 돌아봐요! 좋은 꿈 꾸세요 💭🌙",
+            "오늘 하루도 고생했어요! 내일도 현명한 소비하기! ✅💪",
+            "오늘 얼마나 썼는지 체크해볼까요? 잘 자요~ 💰😴",
+            "오늘의 가계부 정리는 끝났나요? 내일도 파이팅! 📊🌟",
+            "작은 절약도 쌓이면 큰 돈이에요! 오늘도 수고했어요 💎💫"
+        };
+        return defaultWrapUpMessages[(int) (Math.random() * defaultWrapUpMessages.length)];
+    }
+    
+    /**
      * 챌린지 성공 알림 - 실제 운영용
      * 중복 알림 방지 로직 포함
      */

--- a/src/main/java/com/savit/openai/controller/OpenAIController.java
+++ b/src/main/java/com/savit/openai/controller/OpenAIController.java
@@ -135,6 +135,36 @@ public class OpenAIController {
     }
     
     /**
+     * 저장된 하루 마무리 답변 조회
+     */
+    @GetMapping("/daily-wrapup-answers")
+    public ResponseEntity<Map<String, Object>> getDailyWrapUpAnswers() {
+        try {
+            List<String> answers = openAIInternalService.getDailyWrapUpAnswers();
+            List<String> prompts = openAIInternalService.getDailyWrapUpPrompts();
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("totalCount", answers.size());
+            response.put("prompts", prompts);
+            response.put("answers", answers);
+            response.put("serviceEnabled", openAIInternalService.isServiceEnabled());
+            
+            return ResponseEntity.ok(response);
+            
+        } catch (Exception e) {
+            log.error("하루 마무리 답변 조회 중 오류 발생", e);
+            
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("success", false);
+            errorResponse.put("message", "하루 마무리 답변 조회 중 오류가 발생했습니다.");
+            
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(errorResponse);
+        }
+    }
+
+    /**
      * OpenAI 서비스 상태 조회
      */
     @GetMapping("/status")
@@ -142,7 +172,9 @@ public class OpenAIController {
         Map<String, Object> response = new HashMap<>();
         response.put("serviceEnabled", openAIInternalService.isServiceEnabled());
         response.put("answerCount", openAIInternalService.getAnswerCount());
+        response.put("wrapUpAnswerCount", openAIInternalService.getDailyWrapUpAnswers().size());
         response.put("promptCount", openAIInternalService.getPredefinedPrompts().size());
+        response.put("wrapUpPromptCount", openAIInternalService.getDailyWrapUpPrompts().size());
         
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/savit/openai/scheduler/OpenAIDailyScheduler.java
+++ b/src/main/java/com/savit/openai/scheduler/OpenAIDailyScheduler.java
@@ -32,15 +32,19 @@ public class OpenAIDailyScheduler {
             
             long startTime = System.currentTimeMillis();
             
-            // OpenAI 답변 생성 및 저장
+            // OpenAI 랜덤 잔소리 답변 생성 및 저장
             openAIInternalService.generateAndStoreDailyAnswers();
+            
+            // OpenAI 하루 마무리 답변 생성 및 저장
+            openAIInternalService.generateAndStoreDailyWrapUpAnswers();
             
             long endTime = System.currentTimeMillis();
             long duration = endTime - startTime;
             
             log.info("=== OpenAI 일일 답변 갱신 완료 ===");
             log.info("처리 시간: {}ms ({}초)", duration, duration / 1000.0);
-            log.info("생성된 답변 수: {}", openAIInternalService.getAnswerCount());
+            log.info("생성된 랜덤 잔소리 답변 수: {}", openAIInternalService.getAnswerCount());
+            log.info("생성된 하루 마무리 답변 수: {}", openAIInternalService.getDailyWrapUpAnswers().size());
             
         } catch (Exception e) {
             log.error("OpenAI 일일 답변 갱신 중 오류 발생", e);

--- a/src/main/java/com/savit/openai/service/OpenAIInternalService.java
+++ b/src/main/java/com/savit/openai/service/OpenAIInternalService.java
@@ -28,15 +28,31 @@ public class OpenAIInternalService {
     private ObjectMapper objectMapper;
     
     private OkHttpClient httpClient;
+    // 랜덤 잔소리
     private final List<String> dailyAnswers = new ArrayList<>();
+    // 하루 마무리
+    private final List<String> dailyWrapUpAnswers = new ArrayList<>();
 
     // 추가 프롬프트 존재 가능성으로 List 로 생성
+    // 랜덤 잔소리 알림용 프롬프트
     private final List<String> predefinedPrompts = Arrays.asList(
             """
                 Generate 5 witty and slightly nagging alert messages targeted at young professionals in their 20s and 30s who are in their first 0–3 years of work.
                 These messages should be sent when they are using their credit card too frequently, to discourage overspending and encourage budgeting.
-                The tone should be playful, casual, and a bit sarcastic — like a friend who’s concerned.
+                The tone should be playful, casual, and a bit sarcastic — like a friend who's concerned.
                 Include some emojis, Korean-style reactions, and brief messages that feel familiar to people in their 20s. Each message should be one sentence.
+                Output the messages without a numbered list. Answer me in Korean
+            """
+    );
+    
+    // 하루 마무리 알림용 프롬프트
+    private final List<String> dailyWrapUpPrompts = Arrays.asList(
+            """
+                Generate 5 encouraging and reflective end-of-day messages for young professionals in their 20s and 30s who are working on managing their finances and spending habits.
+                These messages should be sent at the end of the day (around 9 PM) to help them reflect on their daily spending and encourage better financial habits for tomorrow.
+                The tone should be warm, supportive, and motivational - like a caring friend who wants to help them succeed financially.
+                Include some emojis and make the messages feel personal and encouraging. Each message should be one sentence and focus on reflection and tomorrow's goals.
+                Topics can include: reflecting on today's spending, preparing for tomorrow's budget, celebrating small financial wins, or gentle reminders about financial goals.
                 Output the messages without a numbered list. Answer me in Korean
             """
     );
@@ -94,6 +110,47 @@ public class OpenAIInternalService {
     }
     
     /**
+     * 하루 마무리 알림 메시지 LLM으로 생성해 저장
+     */
+    public void generateAndStoreDailyWrapUpAnswers() {
+        if (!openAIConfig.isEnabled()) {
+            log.warn("OpenAI 기능이 비활성화되어 있습니다.");
+            return;
+        }
+        
+        log.info("하루 마무리 OpenAI 답변 생성을 시작합니다. 총 {}개 프롬프트", dailyWrapUpPrompts.size());
+        
+        // 기존 답변 리스트 초기화
+        dailyWrapUpAnswers.clear();
+        
+        for (int i = 0; i < dailyWrapUpPrompts.size(); i++) {
+            String prompt = dailyWrapUpPrompts.get(i);
+            try {
+                log.info("하루 마무리 프롬프트 {}/{} 처리 중: {}", i + 1, dailyWrapUpPrompts.size(), 
+                        prompt.length() > 50 ? prompt.substring(0, 50) + "..." : prompt);
+                
+                String answer = callOpenAIAPI(prompt);
+                if (answer != null && !answer.trim().isEmpty()) {
+                    dailyWrapUpAnswers.add(answer);
+                    log.info("하루 마무리 프롬프트 {}/{} 처리 완료", i + 1, dailyWrapUpPrompts.size());
+                } else {
+                    log.warn("하루 마무리 프롬프트 {}/{} 처리 실패: 빈 응답", i + 1, dailyWrapUpPrompts.size());
+                    dailyWrapUpAnswers.add("오늘 하루도 고생하셨어요! 내일도 화이팅! 💪");
+                }
+                
+                // API 호출 간격 조절 (Rate Limit 방지)
+                Thread.sleep(3000);
+                
+            } catch (Exception e) {
+                log.error("하루 마무리 프롬프트 처리 중 오류 발생: {}", prompt, e);
+                dailyWrapUpAnswers.add("오늘 하루도 수고하셨습니다! 내일도 좋은 하루 되세요! 🌟");
+            }
+        }
+        
+        log.info("하루 마무리 LLM 답변 생성 완료. 총 {}개 답변 저장", dailyWrapUpAnswers.size());
+    }
+    
+    /**
      * OpenAI API 호출
      */
     private String callOpenAIAPI(String prompt) throws IOException {
@@ -147,10 +204,24 @@ public class OpenAIInternalService {
     }
     
     /**
+     * 저장된 하루 마무리 답변 리스트 반환
+     */
+    public List<String> getDailyWrapUpAnswers() {
+        return new ArrayList<>(dailyWrapUpAnswers);
+    }
+    
+    /**
      * 미리 정의된 프롬프트 리스트 반환
      */
     public List<String> getPredefinedPrompts() {
         return new ArrayList<>(predefinedPrompts);
+    }
+    
+    /**
+     * 하루 마무리 프롬프트 리스트 반환
+     */
+    public List<String> getDailyWrapUpPrompts() {
+        return new ArrayList<>(dailyWrapUpPrompts);
     }
     
     /**

--- a/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
+++ b/src/main/java/com/savit/scheduler/controller/SchedulerTestController.java
@@ -162,6 +162,33 @@ public class SchedulerTestController {
     }
 
     /**
+     * OpenAI 기반 하루 마무리 알림 스케줄러 수동 실행
+     */
+    @PostMapping("/daily-wrapup")
+    public ResponseEntity<Map<String, Object>> testDailyWrapUpScheduler() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            log.info("=== OpenAI 기반 하루 마무리 알림 스케줄러 수동 테스트 시작 ===");
+
+            // 테스트용 스케줄러 수동 실행
+            randomNaggingScheduler.sendDailyWrapUpNotificationsForTest();
+
+            response.put("status", "success");
+            response.put("message", "OpenAI 기반 하루 마무리 알림 스케줄러 실행 완료");
+            response.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("하루 마무리 알림 스케줄러 테스트 실패", e);
+            response.put("status", "error");
+            response.put("message", "실행 실패: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+
+    /**
      * 스케줄러 대상 사용자 목록 조회
      */
     @GetMapping("/users")

--- a/src/main/java/com/savit/scheduler/job/RandomNaggingScheduler.java
+++ b/src/main/java/com/savit/scheduler/job/RandomNaggingScheduler.java
@@ -68,6 +68,49 @@ public class RandomNaggingScheduler {
     }
 
     /**
+     * 테스트용 - OpenAI 기반 하루 마무리 알림 (테스트 완료로 비활성화)
+     * 서버 시작 1분 후에 딱 한번만 실행되는 테스트용 스케줄러
+     */
+//     @Scheduled(initialDelay = 60000, fixedDelay = Long.MAX_VALUE) // 테스트 완료로 비활성화
+    public void sendDailyWrapUpNotificationsForTest() {
+        log.info("===== 테스트용 OpenAI 기반 하루 마무리 알림 스케줄러 시작 (딱 한번만 실행) =====");
+
+        try {
+            // 1. FCM 토큰이 등록된 활성 사용자 목록 조회
+            List<User> activeUsers = userMapper.findUsersWithFcmTokens();
+
+            if (activeUsers.isEmpty()) {
+                log.info("FCM 토큰이 등록된 사용자가 없습니다.");
+                return;
+            }
+
+            log.info("테스트용 하루 마무리 알림 대상 사용자: {}명", activeUsers.size());
+
+            // 2. 각 사용자별로 100% 확률로 하루 마무리 알림 발송 (테스트용)
+            int sentCount = 0;
+            for (User user : activeUsers) {
+                try {
+                    // 100% 확률로 하루 마무리 알림 발송 (테스트용)
+                    notificationService.sendDailyWrapUpNotification(user.getId());
+                    sentCount++;
+
+                    // 알림 발송 간격 조절 (300ms 대기)
+                    Thread.sleep(300);
+
+                } catch (Exception e) {
+                    log.error("사용자 {} 테스트용 하루 마무리 알림 발송 실패", user.getId(), e);
+                }
+            }
+
+            log.info("===== 테스트용 하루 마무리 알림 스케줄러 완료 - 대상: {}명, 발송: {}명 (딱 한번 실행 완료) =====",
+                    activeUsers.size(), sentCount);
+
+        } catch (Exception e) {
+            log.error("테스트용 하루 마무리 알림 스케줄러 실행 중 오류 발생", e);
+        }
+    }
+
+    /**
      * 운영용 실제 메서드
      * 내부 메서드 호출 방식 - 랜덤 잔소리 알림 (4시간마다)
      * 오전 8시부터 다음날 00시까지 4시간 간격으로 총 4번 실행
@@ -115,12 +158,13 @@ public class RandomNaggingScheduler {
     }
 
     /**
-     * 내부 메서드 호출 방식 - 랜덤 하루 마무리 알림 (매일 오후 9시)
-     * 하루를 마무리하는 시간에 푸시 발송
+     * 운영용 실제 메서드
+     * OpenAI API 기반 하루 마무리 알림 (매일 오후 9시)
+     * 하루를 마무리하는 시간에 OpenAI로 생성된 메시지 또는 기본 메시지로 푸시 발송
      */
     @Scheduled(cron = "0 0 21 * * *") // 매일 오후 9시
     public void sendDailyWrapUpNagging() {
-        log.info("===== 하루 마무리 알림 시작 =====");
+        log.info("===== OpenAI 기반 하루 마무리 알림 시작 =====");
 
         try {
             List<User> activeUsers = userMapper.findUsersWithFcmTokens();
@@ -130,34 +174,24 @@ public class RandomNaggingScheduler {
                 return;
             }
 
-            String[] wrapUpMessages = {
-                "오늘 하루 신용카드는 덜 썼죠? 📝",
-                "내일을 위해 오늘의 지출을 돌아봐요! 💭",
-                "오늘 하루도 고생했어요! 내일도 신용카드 덜쓰기! ✅",
-                "오늘 얼마나 썼는지 체크해볼까요? 💰"
-            };
-
             int sentCount = 0;
             for (User user : activeUsers) {
                 try {
-                    // 30% 확률로 하루 마무리 메시지 발송
-                    if (random.nextInt(100) < 30) {
-                        String message = wrapUpMessages[random.nextInt(wrapUpMessages.length)];
-                        notificationService.sendNotificationToUser(user.getId(), "💬 Savit 한마디", message);
-                        sentCount++;
-
-                        Thread.sleep(300);
-                    }
+                    // OpenAI API 기반 하루 마무리 알림 발송
+                    notificationService.sendDailyWrapUpNotification(user.getId());
+                    sentCount++;
+                    // 알림 발송 간격 조절 (500ms 대기)
+                    Thread.sleep(500);
                 } catch (Exception e) {
                     log.error("사용자 {} 하루 마무리 알림 발송 실패", user.getId(), e);
                 }
             }
 
-            log.info("===== 하루 마무리 잔소리 알림 완료 - 대상: {}명, 발송: {}명 =====",
+            log.info("===== OpenAI 기반 하루 마무리 알림 완료 - 대상: {}명, 발송: {}명 =====",
                     activeUsers.size(), sentCount);
 
         } catch (Exception e) {
-            log.error("하루 마무리 잔소리 알림 실행 중 오류 발생", e);
+            log.error("OpenAI 기반 하루 마무리 알림 실행 중 오류 발생", e);
         }
     }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 하루 마무리 알림 하드코딩된거 LLM 활용 메세지로 전환

## 🔧 주요 변경 사항
- OpenAIInternalService에 하루 마무리 전용 프롬프트 및 생성 로직 추가
- NotificationService에 AI 기반 하루 마무리 알림 메서드 구현
- RandomNaggingScheduler 에 있는 하루 마무리 하드코딩 메시지를 OpenAI 연동으로 전환
- OpenAIDailyScheduler에 하루 마무리 메시지 생성 기능 통합
- OpenAIController에 하루 마무리 답변 조회 API 추가
- SchedulerTestController에 하루 마무리 테스트 엔드포인트 추가

## 📌 관련 이슈
- closes #147 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 하루 마무리 푸시알림 전송 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함