### PR TITLE
[feat] 나의 챌린지 단건 결과 조회 API 추가

### DIFF
--- a/src/main/java/com/savit/challenge/controller/ChallengeResultController.java
+++ b/src/main/java/com/savit/challenge/controller/ChallengeResultController.java
@@ -1,0 +1,31 @@
+package com.savit.challenge.controller;
+
+import com.savit.challenge.dto.ChallengeResultDTO;
+import com.savit.challenge.service.ChallengeResultService;
+import com.savit.security.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/challenge")
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeResultController {
+
+    private final ChallengeResultService resultService;
+    private final JwtUtil jwtUtil;
+
+    @GetMapping("/{challengeId}/my-result")
+    public ResponseEntity<ChallengeResultDTO> getMyResult(
+            @PathVariable Long challengeId,
+            HttpServletRequest request
+    ) {
+        Long userId = jwtUtil.getUserIdFromToken(request);
+        ChallengeResultDTO dto = resultService.getMyChallengeResult(userId, challengeId);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/savit/challenge/dto/ChallengeResultDTO.java
+++ b/src/main/java/com/savit/challenge/dto/ChallengeResultDTO.java
@@ -1,0 +1,29 @@
+package com.savit.challenge.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+public class ChallengeResultDTO {
+    private Long challengeId;
+    private String title;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+    private String type;
+    private BigDecimal goalCount;
+    private BigDecimal goalAmount;
+    private String myStatus;
+    private Long myDeposit;
+    private Long actualCount;
+    private BigDecimal actualAmount;
+    private Long totalParticipants;
+    private Long survivorCount;
+    private Long totalDeposit;
+    private Long forfeitedDeposit;
+    private Boolean ended;
+}

--- a/src/main/java/com/savit/challenge/mapper/ChallengeResultMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeResultMapper.java
@@ -1,0 +1,9 @@
+package com.savit.challenge.mapper;
+
+import com.savit.challenge.dto.ChallengeResultDTO;
+import org.apache.ibatis.annotations.Param;
+
+public interface ChallengeResultMapper {
+    ChallengeResultDTO findMyChallengeResult(@Param("userId") Long userId,
+                                             @Param("challengeId") Long challengeId);
+}

--- a/src/main/java/com/savit/challenge/service/ChallengeResultService.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeResultService.java
@@ -1,0 +1,7 @@
+package com.savit.challenge.service;
+
+import com.savit.challenge.dto.ChallengeResultDTO;
+
+public interface ChallengeResultService {
+    ChallengeResultDTO getMyChallengeResult(Long userId, Long challengeId);
+}

--- a/src/main/java/com/savit/challenge/service/ChallengeResultServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeResultServiceImpl.java
@@ -1,0 +1,31 @@
+package com.savit.challenge.service;
+
+import com.savit.challenge.dto.ChallengeResultDTO;
+import com.savit.challenge.mapper.ChallengeResultMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeResultServiceImpl implements ChallengeResultService {
+
+    private final ChallengeResultMapper mapper;
+
+    @Override
+    public ChallengeResultDTO getMyChallengeResult(Long userId, Long challengeId) {
+        ChallengeResultDTO dto = mapper.findMyChallengeResult(userId, challengeId);
+        if (dto == null) {
+            throw new IllegalArgumentException("참여 이력이 없습니다. challengeId=" + challengeId);
+        }
+
+        // 타입별 불필요 필드 null 처리(프론트 혼란 방지)
+        if ("COUNT".equals(dto.getType())) {
+            dto.setGoalAmount(null);
+            dto.setActualAmount(null);
+        } else if ("AMOUNT".equals(dto.getType())) {
+            dto.setGoalCount(null);
+            dto.setActualCount(null);
+        }
+        return dto;
+    }
+}

--- a/src/main/resources/mapper/challenge/ChallengResultMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengResultMapper.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.savit.challenge.mapper.ChallengeResultMapper">
+
+    <!-- LocalDate 매핑을 확실히: LocalDateTypeHandler 명시 -->
+    <resultMap id="ChallengeResultMap" type="com.savit.challenge.dto.ChallengeResultDTO">
+        <result property="challengeId"      column="challengeId"/>
+        <result property="title"            column="title"/>
+        <result property="startDate"        column="startDate"
+                javaType="java.time.LocalDate"
+                jdbcType="DATE"
+                typeHandler="org.apache.ibatis.type.LocalDateTypeHandler"/>
+        <result property="endDate"          column="endDate"
+                javaType="java.time.LocalDate"
+                jdbcType="DATE"
+                typeHandler="org.apache.ibatis.type.LocalDateTypeHandler"/>
+        <result property="type"             column="type"/>
+        <result property="goalCount"        column="goalCount"/>
+        <result property="goalAmount"       column="goalAmount"/>
+
+        <result property="myStatus"         column="myStatus"/>
+        <result property="myDeposit"        column="myDeposit"/>
+        <result property="actualCount"      column="actualCount"/>
+        <result property="actualAmount"     column="actualAmount"/>
+
+        <result property="totalParticipants" column="totalParticipants"/>
+        <result property="survivorCount"     column="survivorCount"/>
+        <result property="totalDeposit"      column="totalDeposit"/>
+        <result property="forfeitedDeposit"  column="forfeitedDeposit"/>
+
+        <result property="ended"            column="ended"
+                javaType="java.lang.Boolean" jdbcType="TINYINT"/>
+    </resultMap>
+
+    <!-- 단건 + 집계 한방 쿼리 -->
+    <select id="findMyChallengeResult"
+            parameterType="map"
+            resultMap="ChallengeResultMap">
+        SELECT
+        c.id            AS challengeId,
+        c.title         AS title,
+        c.start_date    AS startDate,
+        c.end_date      AS endDate,
+        c.type          AS type,
+        c.target_count  AS goalCount,
+        c.target_amount AS goalAmount,
+
+        up.status            AS myStatus,
+        up.my_fee            AS myDeposit,
+        up.challenge_count   AS actualCount,
+        up.challenge_amount  AS actualAmount,
+
+        COUNT(p.id) AS totalParticipants,
+
+        /* 종료면 SUCCESS, 진행중이면 NOT FAIL */
+        SUM(
+        CASE
+        WHEN c.end_date &lt; CURDATE() AND p.status = 'SUCCESS' THEN 1
+        WHEN c.end_date &gt;= CURDATE() AND p.status &lt;&gt; 'FAIL' THEN 1
+        ELSE 0
+        END
+        ) AS survivorCount,
+
+        COALESCE(SUM(p.my_fee), 0) AS totalDeposit,
+        COALESCE(SUM(CASE WHEN p.status = 'FAIL' THEN p.my_fee ELSE 0 END), 0) AS forfeitedDeposit,
+
+        CASE WHEN c.end_date &lt; CURDATE() THEN 1 ELSE 0 END AS ended
+
+        FROM Challenge c
+        /* 내 참여 레코드 (없으면 화면 자체가 의미 없으니 INNER JOIN) */
+        JOIN ChallengeParticipation up
+        ON up.challenge_id = c.id
+        AND up.user_id      = #{userId}
+
+        /* 집계용 전체 참여자 */
+        JOIN ChallengeParticipation p
+        ON p.challenge_id   = c.id
+
+        WHERE c.id = #{challengeId}
+        GROUP BY
+        c.id, c.title, c.start_date, c.end_date, c.type, c.target_count, c.target_amount,
+        up.status, up.my_fee, up.challenge_count, up.challenge_amount
+    </select>
+
+</mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- `/api/challenge/{challengeId}/my-result` 컨트롤러, 서비스, 매퍼 추가
- JWT 기반 인증 처리 후 해당 사용자의 참여 기록과 집계 데이터 반환
- DTO 설계: 목표/실제 값, 인원 수, 예치금 정보 포함
- Mapper SQL: 진행 중/종료 여부에 따른 survivorCount 계산 로직 포함

## 🔧 주요 변경 사항
- `ChallengeResultController` 추가
- `ChallengeResultService`, `ChallengeResultServiceImpl` 추가
- `ChallengeResultMapper` 인터페이스 및 XML 매퍼 추가
- `ChallengeResultDTO` 생성

## 📌 관련 이슈
- closes #172 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함