### PR TITLE
[feat] 연령대별 카테고리 평균 사용금액 조회 API 추가 (#178)

### DIFF
--- a/src/main/java/com/savit/budget/controller/BudgetController.java
+++ b/src/main/java/com/savit/budget/controller/BudgetController.java
@@ -79,5 +79,14 @@ public class BudgetController {
                 userId, searchDTO.getMonths(), searchDTO.getCategoryIds());
         return ResponseEntity.ok(result);
     }
+
+    // 사용자 + categoryId 기준 또래 월평균 금액(없으면 0)
+    @GetMapping("/peer-avg/{categoryId}")
+    public ResponseEntity<Integer> getMyPeerAvgByCategoryId(@PathVariable Long categoryId,
+                                                            HttpServletRequest request) {
+        Long userId = jwtUtil.getUserIdFromToken(request);
+        int amount = budgetService.getPeerAvgForUserAndCategory(userId, categoryId);
+        return ResponseEntity.ok(amount); // 없으면 0
+    }
 }
 

--- a/src/main/java/com/savit/budget/controller/BudgetController.java
+++ b/src/main/java/com/savit/budget/controller/BudgetController.java
@@ -82,11 +82,11 @@ public class BudgetController {
 
     // 사용자 + categoryId 기준 또래 월평균 금액(없으면 0)
     @GetMapping("/peer-avg/{categoryId}")
-    public ResponseEntity<Integer> getMyPeerAvgByCategoryId(@PathVariable Long categoryId,
+    public ResponseEntity<Map<String, Integer>> getMyPeerAvgByCategoryId(@PathVariable Long categoryId,
                                                             HttpServletRequest request) {
         Long userId = jwtUtil.getUserIdFromToken(request);
         int amount = budgetService.getPeerAvgForUserAndCategory(userId, categoryId);
-        return ResponseEntity.ok(amount); // 없으면 0
+        return ResponseEntity.ok(Map.of("amount", amount)); // 없으면 0
     }
 }
 

--- a/src/main/java/com/savit/budget/mapper/CategoryMapper.java
+++ b/src/main/java/com/savit/budget/mapper/CategoryMapper.java
@@ -1,8 +1,11 @@
 package com.savit.budget.mapper;
 
 import com.savit.budget.domain.CategoryVO;
+import org.apache.ibatis.annotations.Param;
 
 public interface CategoryMapper {
     CategoryVO findById(Long categoryId);
     CategoryVO findByName(String name);
+    Integer findPeerAvgByAgeGroupAndCategoryId(@Param("ageGroup") String ageGroup,
+                                               @Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/savit/budget/service/BudgetService.java
+++ b/src/main/java/com/savit/budget/service/BudgetService.java
@@ -7,4 +7,5 @@ public interface BudgetService {
     void createBudget(BudgetDTO dto, Long userId);
     int changeBudget(BudgetDTO dto, Long userId);
     BudgetVO getBudget(Long userId);
+    int getPeerAvgForUserAndCategory(Long userId, Long categoryId);
 }

--- a/src/main/java/com/savit/budget/service/BudgetServiceImpl.java
+++ b/src/main/java/com/savit/budget/service/BudgetServiceImpl.java
@@ -7,10 +7,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.savit.budget.mapper.CategoryMapper;
+import com.savit.user.domain.User;
+import com.savit.user.service.UserService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.Period;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -19,6 +25,8 @@ import java.time.format.DateTimeFormatter;
 public class BudgetServiceImpl implements BudgetService{
 
     private final BudgetMapper budgetMapper;
+    private final CategoryMapper categoryMapper;
+    private final UserService userService;
 
     @Override
     public void createBudget(BudgetDTO dto, Long userId) {
@@ -47,5 +55,40 @@ public class BudgetServiceImpl implements BudgetService{
     public BudgetVO getBudget(Long userId) {
         String curMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
         return budgetMapper.getBudget(userId,curMonth);
+    }
+
+    @Override
+    public int getPeerAvgForUserAndCategory(Long userId, Long categoryId) {
+        User user = userService.findById(userId);
+        if (user == null) return 0;
+
+        String birth = user.getBirthDate();
+        if (birth == null || birth.isBlank()) return 0;
+
+        Optional<String> ageGroup = toAgeGroup(parseBirthDate(birth));
+        if (ageGroup.isEmpty()) return 0;
+
+        Integer amt = categoryMapper.findPeerAvgByAgeGroupAndCategoryId(ageGroup.get(), categoryId);
+        return amt != null ? amt : 0;
+    }
+
+    private Optional<String> toAgeGroup(Optional<LocalDate> birthOpt) {
+        if (birthOpt.isEmpty()) return Optional.empty();
+        int age = Period.between(birthOpt.get(), LocalDate.now()).getYears();
+        if (age < 20) return Optional.empty();
+        if (age < 30) return Optional.of("20s");
+        if (age < 40) return Optional.of("30s");
+        return Optional.empty(); // 현재 20/30대만 시드 존재
+    }
+
+    private Optional<LocalDate> parseBirthDate(String raw) {
+        for (var fmt : List.of(
+                DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+                DateTimeFormatter.ofPattern("yyyyMMdd")
+        )) {
+            try { return Optional.of(LocalDate.parse(raw, fmt)); }
+            catch (Exception ignore) {}
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/resources/mapper/budget/CategoryMapper.xml
+++ b/src/main/resources/mapper/budget/CategoryMapper.xml
@@ -13,4 +13,12 @@
         SELECT * FROM Category WHERE name = #{name}
     </select>
 
+    <select id="findPeerAvgByAgeGroupAndCategoryId" resultType="int">
+        SELECT p.avg_amount_month
+        FROM PeerAgeGroupAvg p
+        WHERE p.age_group = #{ageGroup}
+          AND p.category_id = #{categoryId}
+            LIMIT 1
+    </select>
+
 </mapper>


### PR DESCRIPTION
## ✅ 작업 내용
- 로그인 사용자의 birth_date를 기반으로 연령대를 계산하여, 해당 연령대/카테고리 평균 사용금액을 조회하는 기능 추가
- BudgetController에 `/peer-avg/{categoryId}` GET API를 추가

## 🔧 주요 변경 사항
- CategoryMapper에 `findPeerAvgByAgeGroupAndCategoryId` 메서드 및 MyBatis 쿼리 추가
- BudgetService에 `getPeerAvgForUserAndCategory` 메서드 정의
- BudgetServiceImpl에서 birth_date 파싱, 나이 계산, 연령대 매핑, PeerAgeGroupAvg 테이블 조회 로직 구현
- BudgetController에 새로운 조회 엔드포인트 추가

## 📌 관련 이슈
- closes #178 

## 🚨 체크리스트
- [ ] 빌드 오류 없음
- [ ] 테스트 코드 작성 또는 실행 확인
- [ ] 커밋 메시지 컨벤션을 지킴
- [ ] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함