### PR TITLE
[refactor] 푸시알림 중복 발송 해결 및 OpenAI 응답 최적화 (#149)

### DIFF
--- a/src/main/java/com/savit/notification/service/NotificationService.java
+++ b/src/main/java/com/savit/notification/service/NotificationService.java
@@ -26,6 +26,7 @@ public class NotificationService {
     private final NotificationMapper notificationMapper;
     private final OpenAIInternalService openAIInternalService;
     private final ChallengeNotificationHistoryMapper challengeNotificationHistoryMapper;
+    private static final String SAVIT_LOGO_ICON = "/assets/img/savit-logo.png";
 
     public String sendNotification(PushNotificationRequest request) {
         return sendNotification(request, null);
@@ -43,17 +44,18 @@ public class NotificationService {
                 .setImage(request.getImage())
                 .build();
 
+
+        //중복 푸시알림 문제 해결위한 코드 : Notification 사용 안하고 putData() 로 데이터 페이로드에 담아 프론트에 전달함
         Message message = Message.builder()
                 .setToken(request.getToken())
-                .setNotification(notification)
-                .putAllData(request.getData() != null ? request.getData() : java.util.Collections.emptyMap())
                 .setWebpushConfig(WebpushConfig.builder()
-                        .setNotification(WebpushNotification.builder()
-                                .setTitle(request.getTitle())
-                                .setBody(request.getBody())
-                                .setIcon("/icon-192x192.png")
-                                .build())
+                        .putHeader("Urgency", "high")
                         .build())
+                .putData("title", request.getTitle())
+                .putData("body", request.getBody())
+                .putData("icon", SAVIT_LOGO_ICON)
+                .putAllData(request.getData() != null ?
+                        request.getData() : java.util.Collections.emptyMap())
                 .build();
 
         try {
@@ -177,12 +179,6 @@ public class NotificationService {
                 for (String message : aiMessages) {
                     String trimmed = message.trim();
                     
-                    // 메타데이터 키워드 제외
-                    if (isMetadataKeyword(trimmed)) {
-                        log.debug("잔소리 메타데이터 제외: {}", trimmed);
-                        continue;
-                    }
-                    
                     // 빈 문자열이 아니고, 10자 이상이고, 한글이 포함된 메시지만 선택
                     if (!trimmed.isEmpty() && trimmed.length() > 10 && trimmed.matches(".*[가-힣].*")) {
                         validMessages.add(trimmed);
@@ -251,12 +247,6 @@ public class NotificationService {
                     
                     log.debug("메시지 {}: '{}' (길이: {})", i, trimmed, trimmed.length());
                     
-                    // 메타데이터 키워드 제외
-                    if (isMetadataKeyword(trimmed)) {
-                        log.info("하루 마무리 메타데이터 제외: {}", trimmed);
-                        continue;
-                    }
-                    
                     // 빈 문자열이 아니고, 10자 이상이고, 한글이 포함된 메시지만 선택
                     if (!trimmed.isEmpty() && trimmed.length() > 10 && trimmed.matches(".*[가-힣].*")) {
                         validMessages.add(trimmed);
@@ -299,51 +289,7 @@ public class NotificationService {
         return defaultWrapUpMessages[(int) (Math.random() * defaultWrapUpMessages.length)];
     }
     
-    /**
-     * 메타데이터 키워드 판별 (Structured Outputs 파싱 개선)
-     * 필요 없는 키워드 다 빼버리기
-     * @param text 검사할 텍스트
-     * @return 메타데이터인지 여부
-     */
-    private boolean isMetadataKeyword(String text) {
-        if (text == null || text.isEmpty()) {
-            return true;
-        }
-        
-        // 정확한 메타데이터 키워드들만
-        String[] exactMatches = {
-            "generatedDate", "generated_date", "type", "tone", 
-            "nagging", "daily_wrap_up", "friendly", "strict", "humorous",
-            "encouraging", "reflective", "motivational",
-            // 하루 마무리 전용 메타데이터 패턴들 추가 완료
-            "end-of-day", "end_of_day", "financial", "habits", 
-            "spending", "budget", "goals", "reflection",
-            "young", "professionals", "messages"
-        };
-        
-        // 정확한 매치만 확인
-        for (String match : exactMatches) {
-            if (text.equals(match)) {
-                log.debug("정확한 메타데이터 매치: {}", text);
-                return true;
-            }
-        }
-        
-        // 날짜 패턴 확인
-        if (text.matches("^\\d{4}-\\d{2}-\\d{2}$")) {
-            log.debug("날짜 패턴 매치: {}", text);
-            return true;
-        }
-        
-        // 매우 짧은 영문 키워드만 (3자 이하)
-        if (text.length() <= 3 && text.matches("^[a-zA-Z_]+$")) {
-            log.debug("짧은 영문 키워드: {}", text);
-            return true;
-        }
-        
-        return false;
-    }
-    
+
     /**
      * 챌린지 성공 알림 - 실제 운영용
      * 중복 알림 방지 로직 포함

--- a/src/main/java/com/savit/openai/controller/OpenAIController.java
+++ b/src/main/java/com/savit/openai/controller/OpenAIController.java
@@ -206,9 +206,6 @@ public class OpenAIController {
                 response.put("message", "Structured Outputs 테스트 성공");
                 response.put("structuredResponse", structuredResponse);
                 response.put("messageCount", structuredResponse.getMessages() != null ? structuredResponse.getMessages().size() : 0);
-                response.put("generatedDate", structuredResponse.getGeneratedDate());
-                response.put("type", structuredResponse.getType());
-                response.put("tone", structuredResponse.getTone());
                 response.put("messages", structuredResponse.getMessages());
             } else {
                 response.put("success", false);
@@ -255,9 +252,6 @@ public class OpenAIController {
                 response.put("message", "Structured Outputs 테스트 성공");
                 response.put("structuredResponse", structuredResponse);
                 response.put("messageCount", structuredResponse.getMessages() != null ? structuredResponse.getMessages().size() : 0);
-                response.put("generatedDate", structuredResponse.getGeneratedDate());
-                response.put("type", structuredResponse.getType());
-                response.put("tone", structuredResponse.getTone());
                 response.put("messages", structuredResponse.getMessages());
             } else {
                 response.put("success", false);

--- a/src/main/java/com/savit/openai/dto/NaggingMessageResponseDTO.java
+++ b/src/main/java/com/savit/openai/dto/NaggingMessageResponseDTO.java
@@ -21,22 +21,8 @@ public class NaggingMessageResponseDTO {
     
     /**
      * 생성된 잔소리 메시지 리스트
-     * 10개의 다양한 잔소리 메시지
+     * 5개의 다양한 잔소리 메시지
      */
     private List<String> messages;
-    
-    /**
-     * 메시지 생성 날짜 (YYYY-MM-DD 형식)
-     */
-    private String generatedDate;
-    
-    /**
-     * 메시지 타입 (항상 "nagging")
-     */
-    private String type;
-    
-    /**
-     * 메시지 톤 (예: "friendly", "strict", "humorous")
-     */
-    private String tone;
+
 }

--- a/src/main/java/com/savit/openai/dto/ResponseFormat.java
+++ b/src/main/java/com/savit/openai/dto/ResponseFormat.java
@@ -57,27 +57,12 @@ public class ResponseFormat {
                     "messages", java.util.Map.of(
                         "type", "array",
                         "items", java.util.Map.of("type", "string"),
-                        "minItems", 10,
-                        "maxItems", 10,
-                        "description", "10개의 다양한 잔소리 메시지"
-                    ),
-                    "generatedDate", java.util.Map.of(
-                        "type", "string",
-                        "pattern", "^\\d{4}-\\d{2}-\\d{2}$",
-                        "description", "메시지 생성 날짜 (YYYY-MM-DD 형식)"
-                    ),
-                    "type", java.util.Map.of(
-                        "type", "string",
-                        "enum", java.util.List.of("nagging"),
-                        "description", "메시지 타입"
-                    ),
-                    "tone", java.util.Map.of(
-                        "type", "string",
-                        "enum", java.util.List.of("friendly", "strict", "humorous"),
-                        "description", "메시지 톤"
+                        "minItems", 5,
+                        "maxItems", 5,
+                        "description", "5개의 다양한 잔소리 메시지"
                     )
                 ))
-                .required(new String[]{"messages", "generatedDate", "type", "tone"})
+                .required(new String[]{"messages"})
                 .additionalProperties(false)
                 .build();
         
@@ -98,27 +83,12 @@ public class ResponseFormat {
                     "messages", java.util.Map.of(
                         "type", "array",
                         "items", java.util.Map.of("type", "string"),
-                        "minItems", 10,
-                        "maxItems", 10,
-                        "description", "10개의 다양한 하루 마무리 메시지"
-                    ),
-                    "generatedDate", java.util.Map.of(
-                        "type", "string",
-                        "pattern", "^\\d{4}-\\d{2}-\\d{2}$",
-                        "description", "메시지 생성 날짜 (YYYY-MM-DD 형식)"
-                    ),
-                    "type", java.util.Map.of(
-                        "type", "string",
-                        "enum", java.util.List.of("daily_wrap_up"),
-                        "description", "메시지 타입"
-                    ),
-                    "tone", java.util.Map.of(
-                        "type", "string",
-                        "enum", java.util.List.of("encouraging", "reflective", "motivational"),
-                        "description", "메시지 톤"
+                        "minItems", 5,
+                        "maxItems", 5,
+                        "description", "5개의 다양한 하루 마무리 메시지"
                     )
                 ))
-                .required(new String[]{"messages", "generatedDate", "type", "tone"})
+                .required(new String[]{"messages"})
                 .additionalProperties(false)
                 .build();
         

--- a/src/main/java/com/savit/openai/dto/WrapUpMessageResponseDTO.java
+++ b/src/main/java/com/savit/openai/dto/WrapUpMessageResponseDTO.java
@@ -21,22 +21,7 @@ public class WrapUpMessageResponseDTO {
     
     /**
      * 생성된 하루 마무리 메시지 리스트
-     * 10개의 다양한 마무리 메시지
+     * 5개의 다양한 마무리 메시지
      */
     private List<String> messages;
-    
-    /**
-     * 메시지 생성 날짜 (YYYY-MM-DD 형식)
-     */
-    private String generatedDate;
-    
-    /**
-     * 메시지 타입 (항상 "daily_wrap_up")
-     */
-    private String type;
-    
-    /**
-     * 메시지 톤 (예: "encouraging", "reflective", "motivational")
-     */
-    private String tone;
 }

--- a/src/main/java/com/savit/openai/service/OpenAIInternalService.java
+++ b/src/main/java/com/savit/openai/service/OpenAIInternalService.java
@@ -293,8 +293,8 @@ public class OpenAIInternalService {
                 }
                 dailyAnswers.add(structuredMessages.toString().trim());
                 
-                log.info("Structured Outputs 잔소리 메시지 생성 완료 - 생성된 메시지: {}개, 타입: {}, 톤: {}", 
-                         response.getMessages().size(), response.getType(), response.getTone());
+                log.info("Structured Outputs 잔소리 메시지 생성 완료 - 생성된 메시지: {}개",
+                         response.getMessages().size());
                 
             } else {
                 log.warn("Structured Outputs 잔소리 메시지 생성 실패: 빈 응답");
@@ -334,8 +334,8 @@ public class OpenAIInternalService {
                 }
                 dailyWrapUpAnswers.add(structuredMessages.toString().trim());
                 
-                log.info("Structured Outputs 하루 마무리 메시지 생성 완료 - 생성된 메시지: {}개, 타입: {}, 톤: {}", 
-                         response.getMessages().size(), response.getType(), response.getTone());
+                log.info("Structured Outputs 하루 마무리 메시지 생성 완료 - 생성된 메시지: {}개",
+                         response.getMessages().size());
                 
             } else {
                 log.warn("Structured Outputs 하루 마무리 메시지 생성 실패: 빈 응답");


### PR DESCRIPTION


## ✅ 작업 내용
- 푸시알림 중복 발송 문제 해결 및 OpenAI Structured Outputs 응답 최적화

## 🔧 주요 변경 사항
- 푸시알림 Message 객체를 putData() 방식으로 변경하여 중복 발송 방지 : 데이터 페이로드에 담아서 프론트에 전달
- OpenAI Structured Outputs에서 불필요한 메타데이터 필드 제거 : `required` 필드를 `messages`만으로 단순화
- JSON Schema 단순화
- DTO 클래스에서 generatedDate, type, tone 필드 제거
- 응답 처리 로직 최적화로 성능 개선

## 📌 관련 이슈
- closes #149 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 푸시알림 중복 발송 문제 완전 해결
- [x] 불필요한 메타데이터 제거로 토큰 사용량 최적화
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함