### PR TITLE
[refactor] 카드 등록 시 ocr 순서 변경 (#183)

### DIFF
--- a/src/main/java/com/savit/card/controller/CardController.java
+++ b/src/main/java/com/savit/card/controller/CardController.java
@@ -9,6 +9,7 @@ import com.savit.security.JwtUtil;
 import com.savit.user.domain.User;
 import com.savit.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,52 +24,57 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/cards")
 @RequiredArgsConstructor
+@Slf4j
 public class CardController {
 
     private final CardService cardService;
     private final JwtUtil jwtUtil;
     private final UserService userService;
     private final ClovaOCRService clovaOCRService;
-    @PostMapping(value="/register", consumes=MediaType.MULTIPART_FORM_DATA_VALUE)
+
+    // OCR 로 카드 번호 추출
+    @PostMapping(value = "/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> extractCardNumber(@RequestParam("cardImage") MultipartFile cardImage) {
+        try {
+            if (cardImage == null || cardImage.isEmpty()) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "카드 이미지가 필요합니다."));
+            }
+
+            String ocrCardNumber = clovaOCRService.extractCardNumber(cardImage);
+
+            return ResponseEntity.ok(Map.of(
+                    "cardNumber", ocrCardNumber,
+                    "message", "카드번호가 성공적으로 인식되었습니다."
+            ));
+        } catch (Exception e) {
+            log.error("OCR 카드번호 추출 중 오류 발생", e);
+            return ResponseEntity.status(500)
+                    .body(Map.of("error", "카드번호 인식에 실패했습니다: " + e.getMessage()));
+        }
+    }
+
+    // 카드 등록
+    @PostMapping("/register")
     public ResponseEntity<?> registerCardAndFetch(
-            @RequestParam("organization") String organization,
-            @RequestParam("loginId") String loginId,
-            @RequestParam("loginPw") String loginPw,
-            @RequestParam("birthDate") String birthDate,
-            @RequestParam("cardPassword") String cardPassword,
-            @RequestParam(value="cardImage", required=false) MultipartFile cardImage,
-            HttpServletRequest request) throws Exception {
+            @RequestBody @Valid CardRegisterRequestDTO req,
+            HttpServletRequest request) {
 
-
-        System.out.println("=== @RequestParam으로 받은 데이터 ===");
-        System.out.println("organization: [" + organization + "]");
-        System.out.println("loginId: [" + loginId + "]");
-        System.out.println("loginPw: [" + loginPw + "]");
-        System.out.println("birthDate: [" + birthDate + "]");
-        System.out.println("cardPassword: [" + cardPassword + "]");
-        System.out.println("cardImage: [" + (cardImage != null ? cardImage.getOriginalFilename() : "null") + "]");
 
         try {
-            // DTO 수동 생성
-            CardRegisterRequestDTO req = new CardRegisterRequestDTO();
-            req.setOrganization(organization);
-            req.setLoginId(loginId);
-            req.setLoginPw(loginPw);
-            req.setBirthDate(birthDate);
-            req.setCardPassword(cardPassword);
-            req.setCardImage(cardImage);
-
-            // OCR로 카드번호 추출
-            if(req.getCardImage() != null && !req.getCardImage().isEmpty()){
-                String ocrCardNumber = clovaOCRService.extractCardNumber(req.getCardImage());
-                req.setEncryptedCardNo(ocrCardNumber);
-            }
             Long userId = jwtUtil.getUserIdFromToken(request);
+
+            // 카드번호가 없으면 에러
+            if (req.getEncryptedCardNo() == null || req.getEncryptedCardNo().isBlank()) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "카드번호가 필요합니다. 먼저 OCR로 카드번호를 인식해주세요."));
+            }
 
             String connectedId =
                     cardService.registerAccount(req);
 
-            String birthForDb = toYyyyDashMmDashDd(birthDate);
+            // 생년월일 업데이트
+            String birthForDb = toYyyyDashMmDashDd(req.getBirthDate());
             if (birthForDb != null && !birthForDb.isBlank()) {
                 userService.updateBirthDateIfNull(userId, birthForDb);
             }

--- a/src/main/java/com/savit/card/dto/CardRegisterRequestDTO.java
+++ b/src/main/java/com/savit/card/dto/CardRegisterRequestDTO.java
@@ -11,11 +11,14 @@ import javax.validation.constraints.NotBlank;
 public class CardRegisterRequestDTO {
     @NotBlank(message = "기관코드는 필수입니다.")
     private String organization;
+    @NotBlank(message = "로그인 ID는 필수입니다.")
     private String loginId;
+    @NotBlank(message = "로그인 비밀번호는 필수입니다.")
     private String loginPw;
+    @NotBlank(message = "생년월일은 필수입니다.")
     private String birthDate;
+    @NotBlank(message = "카드 비밀번호는 필수입니다.")
     private String cardPassword;
+    @NotBlank(message = "카드번호는 필수입니다.")
     private String encryptedCardNo;
-    // ocr 인식할 카드 이미지
-    private MultipartFile cardImage;
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 기존 일원화된 카드 등록 엔드포인트를 ocr 인식과 카드 등록 2개 로 분리

## 🔧 주요 변경 사항
- CardController: /api/cards/ocr - 카드 번호 추출, /api/cards/register - 필수 요소들 한꺼번에 post
- CardRegisterRequestDTO: cardImage 필드 제거 

## 📌 관련 이슈
- closes #183 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함