### PR TITLE
fix: 참여한 챌린지 제외하고 참여가능 챌린지 조회 (#185)

### DIFF
--- a/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/com/savit/challenge/mapper/ChallengeMapper.java
@@ -26,9 +26,9 @@ public interface ChallengeMapper {
     // 리스트 조회
     List<Long> findSuccessfulWeeklyCategories(Long userId);
 
-    List<ChallengeListDTO> findWeeklyChallenges();
+    List<ChallengeListDTO> findWeeklyChallenges(Long userId);
 
-    List<ChallengeListDTO> findMonthlyChallenges(Long categoryid);
+    List<ChallengeListDTO> findMonthlyChallenges(Long userId, Long categoryid);
 
 
     // 참여중인 챌린지 조회

--- a/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/savit/challenge/service/ChallengeServiceImpl.java
@@ -37,11 +37,11 @@ public class ChallengeServiceImpl implements ChallengeService {
     public List<ChallengeListDTO> getChallengeList(Long userId) {
         List<Long> categoryids = challengeMapper.findSuccessfulWeeklyCategories(userId);
 
-        List<ChallengeListDTO> weeklyList = challengeMapper.findWeeklyChallenges();
+        List<ChallengeListDTO> weeklyList = challengeMapper.findWeeklyChallenges(userId);
 
         if (!categoryids.isEmpty()) {
             for (Long categoryid : categoryids) {
-                List<ChallengeListDTO> monthlyList = challengeMapper.findMonthlyChallenges(categoryid);
+                List<ChallengeListDTO> monthlyList = challengeMapper.findMonthlyChallenges(userId, categoryid);
                 weeklyList.addAll(monthlyList);
             }
         }

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -49,6 +49,7 @@
                  inner join Category as cat on c.category_id = cat.id
         where current_date &lt;  c.start_date
           and c.duration_weeks = 1
+          and cp.challenge_id is null
         order by c.start_date asc
     </select>
 
@@ -60,6 +61,7 @@
         where current_date &lt;  c.start_date
           and c.duration_weeks = 4
           and c.category_id = #{categoryId}
+          and cp.challenge_id is null
         order by c.start_date asc
     </select>
 

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -47,22 +47,28 @@
         select c.id as challenge_id, c.title, c.start_date, c.end_date, cat.name as categoryName
         from Challenge c
                  inner join Category as cat on c.category_id = cat.id
-        where current_date &lt;  c.start_date
+                 left join ChallengeParticipation cp on c.id = cp.challenge_id
+            and cp.user_id = #{userId}
+            and cp.status = 'PARTICIPATING'
+        where current_date &lt; c.start_date
           and c.duration_weeks = 1
           and cp.challenge_id is null
         order by c.start_date asc
     </select>
 
-    <!-- 1번 기준 충족시 4주 챌린지 목록 조회 -->
+
+    <!-- 1번 기준 충족시 4주 챌린지 목록 조회 (현재 참여중인 챌린지 제외) -->
     <select id="findMonthlyChallenges" resultType="com.savit.challenge.dto.ChallengeListDTO">
         select c.id as challenge_id, c.title, c.start_date, c.end_date, cat.name as categoryName
         from Challenge c
                  inner join Category as cat on c.category_id = cat.id
-        where current_date &lt;  c.start_date
+                 left join ChallengeParticipation cp on c.id = cp.challenge_id
+            and cp.user_id = #{userId}
+            and cp.status = 'PARTICIPATING'
+        where current_date &lt; c.start_date
           and c.duration_weeks = 4
           and c.category_id = #{categoryId}
           and cp.challenge_id is null
-        order by c.start_date asc
     </select>
 
 


### PR DESCRIPTION
## ✅ 작업 내용
- 참여 가능 챌린지에서 참여중 챌린지 제외하도록

## 🔧 주요 변경 사항
-  ChallengeMapper의 findWeeklyChallenges, findMonthlyChallenges: challenge_id is null 추가

## 📌 관련 이슈
- closes #185 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함