### PR TITLE
[feat(security)] HTTPS 리다이렉트 적용 (#187)

### DIFF
--- a/src/main/java/com/savit/config/WebConfig.java
+++ b/src/main/java/com/savit/config/WebConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -48,7 +49,11 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
         CharacterEncodingFilter encodingFilter = new CharacterEncodingFilter();
         encodingFilter.setEncoding("UTF-8");
         encodingFilter.setForceEncoding(true);
-        return new Filter[]{ encodingFilter };
+
+        // X-Forwarded-Proto 등 헤더를 읽어서 request.getScheme() 수정
+        ForwardedHeaderFilter forwardedHeaderFilter = new ForwardedHeaderFilter();
+
+        return new Filter[]{ encodingFilter, forwardedHeaderFilter };
     }
 
     // 404 예외 발생 설정

--- a/src/main/java/com/savit/security/SecurityConfig.java
+++ b/src/main/java/com/savit/security/SecurityConfig.java
@@ -25,6 +25,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
+                .requiresChannel()
+                .anyRequest()
+                .requiresSecure()   // 모든 요청은 HTTPS로만
+                .and()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()


### PR DESCRIPTION
## ✅ 작업 내용
- HTTPS 적용 (Spring Legacy + Nginx 연동)
- ForwardedHeaderFilter 등록
- SecurityConfig에 requiresChannel 설정 추가

## 🔧 주요 변경 사항
- WebConfig.java: ForwardedHeaderFilter 필터 추가
- SecurityConfig.java: requiresChannel().anyRequest().requiresSecure() 적용
- Nginx: proxy_set_header X-Forwarded-Proto/Host/Port 보강

## 📌 관련 이슈
- closes #187 

## 🚨 체크리스트
- [ ] HTTP 요청 시 HTTPS로 올바르게 리다이렉트 되는지 확인
- [ ] 카카오 로그인 redirect_uri가 https:// 로 정상 반환되는지 확인