### PR TITLE
[fix] /card/register 엔드포인트에 JSON consumes/produces 명시로 415 방지 (#191)

### DIFF
--- a/src/main/java/com/savit/card/controller/CardController.java
+++ b/src/main/java/com/savit/card/controller/CardController.java
@@ -55,7 +55,11 @@ public class CardController {
     }
 
     // 카드 등록
-    @PostMapping("/register")
+    @PostMapping(
+            value = "/register",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
     public ResponseEntity<?> registerCardAndFetch(
             @RequestBody @Valid CardRegisterRequestDTO req,
             HttpServletRequest request) {


### PR DESCRIPTION
## ✅ 작업 내용
- `/card/register` API에서 `Content-Type: application/json` 요청 시 발생하던 `415 Unsupported Media Type` 오류 수정
- `CardController`의 `@PostMapping`에 `consumes/produces` 속성 추가

## 🔧 주요 변경 사항
- `CardController.java`
  - `@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)` 명시
- 프론트엔드 JSON 요청 정상 처리 확인

## 📌 관련 이슈
- closes #191 

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] JSON 요청으로 카드 등록 API 정상 동작 확인
- [x] 커밋 메시지 컨벤션(`fix(card): ...`) 준수
- [x] 리뷰어가 이해할 수 있도록 충분한 설명 작성
