### PR TITLE
[fix] 사용자가 선택한 카드 1장만 등록되도록 수정 (#197)

### DIFF
--- a/src/main/java/com/savit/card/controller/CardController.java
+++ b/src/main/java/com/savit/card/controller/CardController.java
@@ -6,7 +6,6 @@ import com.savit.card.dto.CardRenameRequestDTO;
 import com.savit.card.service.CardService;
 import com.savit.card.service.ClovaOCRService;
 import com.savit.security.JwtUtil;
-import com.savit.user.domain.User;
 import com.savit.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -64,7 +62,6 @@ public class CardController {
             @RequestBody @Valid CardRegisterRequestDTO req,
             HttpServletRequest request) {
 
-
         try {
             Long userId = jwtUtil.getUserIdFromToken(request);
 
@@ -74,8 +71,7 @@ public class CardController {
                         .body(Map.of("error", "카드번호가 필요합니다. 먼저 OCR로 카드번호를 인식해주세요."));
             }
 
-            String connectedId =
-                    cardService.registerAccount(req);
+            String connectedId = cardService.registerAccount(req);
 
             // 생년월일 업데이트
             String birthForDb = toYyyyDashMmDashDd(req.getBirthDate());
@@ -83,18 +79,38 @@ public class CardController {
                 userService.updateBirthDateIfNull(userId, birthForDb);
             }
 
-            List<Map<String,Object>> cards =
-                    cardService.fetchCardList(
-                            connectedId,
-                            req.getOrganization(),
-                            req.getBirthDate()
-                    );
+            List<Map<String,Object>> cards = cardService.fetchCardList(
+                    connectedId,
+                    req.getOrganization(),
+                    req.getBirthDate()
+            );
 
-            cardService.saveCards(cards, connectedId, req.getOrganization(), userId, req.getEncryptedCardNo(), req.getCardPassword());
+            var pickedOpt = cardService.pickOneMasked(
+                    cards,
+                    req.getOrganization(),
+                    req.getEncryptedCardNo()
+            );
+
+            if (pickedOpt.isEmpty()) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "error", "입력한 카드번호와 일치하는 카드를 찾지 못했습니다. (마스킹 포함 비교)"
+                ));
+            }
+
+            Map<String, Object> picked = pickedOpt.get();
+
+            cardService.saveCards(
+                    List.of(picked),
+                    connectedId,
+                    req.getOrganization(),
+                    userId,
+                    req.getEncryptedCardNo(),
+                    req.getCardPassword()
+            );
 
             return ResponseEntity.ok(Map.of(
                     "connectedId", connectedId,
-                    "cards",       cards
+                    "cards", List.of(picked)
             ));
         } catch (Exception e) {
             return ResponseEntity.status(500)

--- a/src/main/java/com/savit/card/service/CardService.java
+++ b/src/main/java/com/savit/card/service/CardService.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional; // ✅ 추가
 
 @Slf4j
 @Service
@@ -92,7 +93,6 @@ public class CardService {
         );
         log.info("[CODEF] createAccount 응답 = {}", resp);
 
-
         Map<String, Object> map = new ObjectMapper().readValue(resp, Map.class);
         Object dataObj = map.get("data");
 
@@ -107,6 +107,70 @@ public class CardService {
         }
 
         return cardList;
+    }
+
+    private String digitsOnly(String s) {
+        return s == null ? "" : s.replaceAll("\\D", "");
+    }
+
+    private String userLast4(String userInput) {
+        String d = digitsOnly(userInput);
+        return d.length() >= 4 ? d.substring(d.length() - 4) : d;
+    }
+
+    private String visiblePrefix(String masked, int n) {
+        if (masked == null) return "";
+        StringBuilder sb = new StringBuilder();
+        for (char c : masked.toCharArray()) {
+            if (Character.isDigit(c)) sb.append(c);
+            else if (c == '*') break; // 마스킹 시작되면 중단
+        }
+        String all = sb.toString();
+        return all.length() > n ? all.substring(0, n) : all;
+    }
+
+    private String visibleSuffix(String masked, int n) {
+        if (masked == null) return "";
+        StringBuilder revDigits = new StringBuilder();
+        for (int i = masked.length() - 1; i >= 0; i--) {
+            char c = masked.charAt(i);
+            if (Character.isDigit(c)) revDigits.append(c);
+            else if (c == '*') break;
+        }
+        String suf = revDigits.reverse().toString();
+        return suf.length() > n ? suf.substring(suf.length() - n) : suf;
+    }
+
+    public boolean matchesUserCardMasked(Map<String, Object> codefCard,
+                                         String requestedOrganization,
+                                         String userInputCardNo) {
+        String orgInResp = (String) (codefCard.getOrDefault("organization", codefCard.get("resIssuerCode")));
+        if (orgInResp != null && requestedOrganization != null && !requestedOrganization.equals(orgInResp)) {
+            return false;
+        }
+
+        String masked = (String) codefCard.get("resCardNo");
+        String visPrefix = visiblePrefix(masked, 8);
+        String visSuffix = visibleSuffix(masked, 4);
+
+        String userDigits = digitsOnly(userInputCardNo);
+        if (userDigits.length() < 10) return false;
+
+        String userPrefix8 = userDigits.substring(0, Math.min(8, userDigits.length()));
+        String userSuf4    = userLast4(userDigits);
+
+        boolean prefixOk = visPrefix.isEmpty() || userPrefix8.startsWith(visPrefix);
+        boolean suffixOk = visSuffix.isEmpty() || userSuf4.endsWith(visSuffix);
+
+        return prefixOk && suffixOk;
+    }
+
+    public Optional<Map<String, Object>> pickOneMasked(List<Map<String, Object>> cardList,
+                                                       String organization,
+                                                       String userInputCardNo) {
+        return cardList.stream()
+                .filter(c -> matchesUserCardMasked(c, organization, userInputCardNo))
+                .findFirst();
     }
 
     public void saveCards(List<Map<String, Object>> cardDataList,


### PR DESCRIPTION
## ✅ 작업 내용
- CODEF 응답(`resCardNo`) 마스킹(예: `51073768****553*`)을 고려한 매칭 로직 추가
- 같은 조직 + visible prefix/suffix 기준으로 **정확히 1장만** 선택/저장
- Controller에서 fetch → pickOneMasked → save 순서로 변경

## 🔧 주요 변경 사항
- `CardService`: `visiblePrefix`, `visibleSuffix`, `matchesUserCardMasked`, `pickOneMasked` 추가
- `CardController`: 저장 전 1장 선택 로직 적용

## 📌 관련 이슈
closes #197

## 🚨 체크리스트
- [x] 빌드 오류 없음
- [x] 수동 테스트로 다양한 마스킹 패턴 검증
- [x] 기존 저장 로직 영향 범위 최소화 (미매칭 시 400 반환)

## 🧪 테스트 방법
1. 카드 등록 API 호출 시, 사용자가 입력한 카드번호(숫자만 기준)와  
   CODEF 응답의 보이는 접두/접미를 비교
2. 끝자리가 `*`로 마스킹되어 3자리만 보이는 경우에도 suffix `endsWith`로 매칭 확인
3. 성공 시 DB에 단 1장만 insert, 매칭 실패 시 400 응답 반환