### PR TITLE
[chore] 배포 환경에 맞춰 카카오 로그인 콜백 URL 변경 (#201)

### DIFF
--- a/src/main/java/com/savit/user/controller/AuthController.java
+++ b/src/main/java/com/savit/user/controller/AuthController.java
@@ -51,7 +51,7 @@ public class AuthController {
         // 에러 처리
         if (error != null) {
             log.error("카카오 인증 에러: {}", error);
-            String errorUrl = "http://localhost:5173/auth/error?message=" +
+            String errorUrl = "https://savit.cloud/auth/error?message=" +
                     URLEncoder.encode("카카오 인증이 취소되었습니다.", "UTF-8");
             response.sendRedirect(errorUrl);
             return;
@@ -60,7 +60,7 @@ public class AuthController {
         // code 파라미터 체크
         if (code == null || code.trim().isEmpty()) {
             log.error("인가 코드가 없습니다.");
-            String errorUrl = "http://localhost:5173/auth/error?message=" +
+            String errorUrl = "https://savit.cloud/auth/error?message=" +
                     URLEncoder.encode("인가 코드가 필요합니다.", "UTF-8");
             response.sendRedirect(errorUrl);
             return;
@@ -77,7 +77,7 @@ public class AuthController {
             log.info("refreshToken = {}", loginResponse.getRefreshToken());
 
             // 성공 시 프론트엔드로 리다이렉트 (토큰 포함)
-            String redirectUrl = "http://localhost:5173/auth/login/callback" +
+            String redirectUrl = "https://savit.cloud/auth/login/callback" +
                     "?accessToken=" + URLEncoder.encode(loginResponse.getAccessToken(), "UTF-8") +
                     "&refreshToken=" + URLEncoder.encode(loginResponse.getRefreshToken(), "UTF-8");
 
@@ -88,7 +88,7 @@ public class AuthController {
         } catch (Exception e) {
             log.error("카카오 로그인 처리 실패", e);
             try {
-                String errorUrl = "http://localhost:5173/auth/error?message=" +
+                String errorUrl = "https://savit.cloud/auth/error?message=" +
                         URLEncoder.encode("로그인 처리 중 오류가 발생했습니다.", "UTF-8");
                 response.sendRedirect(errorUrl);
             } catch (IOException ioException) {


### PR DESCRIPTION
✅ 작업 내용

카카오 로그인 콜백 URL을 로컬 개발환경에서 실제 배포 도메인으로 변경
하드코딩된 localhost:5173 주소를 savit.cloud로 수정

🔧 주요 변경 사항

수정 파일: AuthController.java
에러 리다이렉트 URL: http://localhost:5173/auth/error → https://savit.cloud/auth/error
성공 콜백 리다이렉트 URL: http://localhost:5173/auth/login/callback → https://savit.cloud/auth/login/callback
프로토콜 변경: HTTP → HTTPS 적용

📌 관련 이슈

closes #201 

🚨 체크리스트

- [x] 빌드 오류 없음
- [x] 테스트 코드 작성 또는 실행 확인
- [x] 커밋 메시지 컨벤션을 지킴
- [x] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함
